### PR TITLE
Add GitHub Enterprise base URL support

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,12 +50,25 @@
       "Bash(mkdir -p specs/043-reviewer-assignee/checklists)",
       "Bash(cp .specify/templates/spec-template.md specs/043-reviewer-assignee/spec.md)",
       "Bash(jobs -l)",
-      "Bash(kill %1)"
+      "Bash(kill %1)",
+      "Bash(ls /home/node/.claude/skills/ 2>/dev/null && echo \"exists\" || echo \"not found\")",
+      "Read(//home/node/.claude/skills/**)",
+      "Bash(ls /home/node/.claude/plugins/cache/claude-plugins-official/skill-creator/unknown/skills/ 2>/dev/null | head -20)",
+      "Read(//home/node/.claude/plugins/cache/claude-plugins-official/skill-creator/unknown/skills/**)",
+      "Bash(# Check where other skills are installed by looking at the config *)",
+      "Read(//home/node/.claude/**)",
+      "Bash(mkdir -p /home/node/.claude/skills/learned/create-pr)",
+      "Edit(~/.claude/skills/learned/**)",
+      "Bash(mkdir -p /home/node/.claude/skills/learned/create-pr/evals)",
+      "Bash(gh label *)",
+      "Edit(/.claude/skills/create-pr/**)"
     ],
     "additionalDirectories": [
       "/tmp",
       "/workspaces/sealion/prisma/migrations",
-      "/workspaces/sealion/specs/"
+      "/workspaces/sealion/specs/",
+      "/home/node/.claude/skills/learned",
+      "/home/node/.claude/skills/learned/create-pr"
     ]
   },
   "enabledPlugins": {

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: create-pr
+description: Create a pull request from the current branch targeting the develop branch. Use this skill whenever the user asks to create a PR, open a pull request, submit a PR, or push changes for review. Always use this skill for PR creation tasks, do not just run gh pr create manually.
+---
+
+# PR Creation Skill
+
+Create a pull request from the current branch to `develop`, with an English title, a concise bullet-point description, and an appropriate label.
+
+## Step-by-step workflow
+
+### 1. Gather branch info
+
+```bash
+git branch --show-current
+```
+
+Then get the full commit history since `develop`:
+
+```bash
+git log develop..HEAD --oneline
+git diff develop...HEAD --stat
+```
+
+### 2. Determine if this is a Spec Kit branch
+
+A branch is a **Spec Kit branch** if a file exists at `specs/<branch-name>/spec.md` relative to the repo root.
+
+```bash
+# Example: current branch = 044-ghe-url-support
+# Check: specs/044-ghe-url-support/spec.md
+```
+
+If the file exists → this is a Spec Kit branch. Read it and use the first heading (the `#` line) as the source of truth for what the feature is. Translate it concisely to English for the PR title.
+
+If the file does not exist → derive the title from the git log / diff summary.
+
+### 3. Craft the PR title
+
+Keep it under 72 characters. Use sentence case (no period at end). The title should describe *what* the change does, not *how*.
+
+**Spec Kit branch example:**
+- spec.md heading: `# Feature spec: GitHub Enterprise URL support`
+- PR title: `Add GitHub Enterprise base URL support`
+
+**Non-Spec Kit branch example:**
+- Commits: `fix: null pointer in auth middleware`, `fix: token expiry not handled`
+- PR title: `Fix auth middleware null pointer and token expiry handling`
+
+### 4. Write the PR description
+
+Write a short bullet-point list in English summarising *what changed and why*. Aim for 3–6 bullets. Each bullet should be one complete sentence.
+
+Focus on:
+- New features or capabilities added
+- Bugs fixed (and what the bug was)
+- Notable implementation choices (e.g., added pagination, validation)
+- Test coverage added
+
+Example format:
+```
+## Summary
+- Add `baseUrl` field to GitHub provider configuration to support GitHub Enterprise.
+- Validate the URL format on save; show an inline error for invalid values.
+- Disable the URL input unless the GHE checkbox is checked.
+- Extend the GitHub API client to prefix all requests with the configured base URL.
+- Add unit tests covering URL validation and API client URL construction.
+```
+
+### 5. Choose a label
+
+Select **one or more** of the following that best describe the PR:
+
+| Label | When to use |
+|---|---|
+| `enhancement` | New feature or improvement to existing functionality |
+| `bug` | A fix for a defect or incorrect behaviour |
+| `documentation` | Changes primarily to docs, comments, or specs |
+
+It's fine to apply both `enhancement` and `bug` if the PR mixes features and fixes.
+
+### 6. Create the PR
+
+Use `gh pr create` targeting `develop`:
+
+```bash
+gh pr create \
+  --base develop \
+  --title "<title>" \
+  --label "<label>" \
+  --body "$(cat <<'EOF'
+## Summary
+- <bullet 1>
+- <bullet 2>
+- <bullet 3>
+EOF
+)"
+```
+
+If the label does not exist in the repository yet, omit `--label` and note it to the user.
+
+### 7. Report back
+
+After the PR is created, output the PR URL so the user can navigate to it directly.

--- a/.claude/skills/create-pr/evals/evals.json
+++ b/.claude/skills/create-pr/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "create-pr",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "PRを作成してください",
+      "expected_output": "A PR is created targeting the develop branch. The title is in English derived from the spec.md (since 044-ghe-url-support is the current branch and has a spec.md). The description has bullet points in English. An appropriate label (enhancement) is applied.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Please create a pull request for this branch",
+      "expected_output": "A PR is created targeting the develop branch. The title is in English. The description summarizes the changes in bullet points. A label is selected.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "今の変更をレビューに出したいです。プルリクを作ってもらえますか？",
+      "expected_output": "A PR is created targeting the develop branch. The title comes from spec.md content (translated to English). Description is a concise bullet list in English. Label is appropriate.",
+      "files": []
+    }
+  ]
+}

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/043-reviewer-assignee"
+  "feature_directory": "specs/044-ghe-url-support"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,8 @@ See [AGENTS.md](./AGENTS.md) for full architecture, coding conventions, testing 
 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read the current plan
+shell commands, and other important information, read the current plan:
+[specs/044-ghe-url-support/plan.md](specs/044-ghe-url-support/plan.md)
 <!-- SPECKIT END -->
 
 ## Active Technologies

--- a/src/app/api/providers/[id]/route.ts
+++ b/src/app/api/providers/[id]/route.ts
@@ -106,6 +106,24 @@ function resolveCredentials(
   };
 }
 
+/**
+ * Validates the base URL value against the provider's mode constraints.
+ * @param rawBaseUrl - The raw baseUrl from the request body (`undefined` = not sent).
+ * @param mode - The provider's `baseUrlMode`.
+ * @param normalizedBaseUrl - The normalised value (after trimming and empty-string handling).
+ * @returns A `Response` error if the combination is invalid, or `null` if it is acceptable.
+ */
+function validateBaseUrlRequest(
+  rawBaseUrl: string | undefined,
+  mode: string | undefined,
+  normalizedBaseUrl: string | null | undefined,
+): Response | null {
+  if (rawBaseUrl !== undefined && mode === "none") { return fail("INVALID_BODY", 400); }
+  if (mode === "required" && !normalizedBaseUrl) { return fail("MISSING_FIELDS", 400); }
+  if (normalizedBaseUrl && !isValidBaseUrl(normalizedBaseUrl)) { return fail("INVALID_BASE_URL", 400); }
+  return null;
+}
+
 type NormalizedBaseUrl = {
   /** URL to write to the DB: `null` = clear, `undefined` = no change, `string` = new URL. */
   toStore: string | null | undefined;
@@ -115,6 +133,7 @@ type NormalizedBaseUrl = {
 
 /**
  * Normalises the raw `baseUrl` from a PATCH request body.
+ * Trims whitespace before storing and validating.
  * @param mode - The provider's `baseUrlMode` (`"optional"`, `"required"`, or `"none"`).
  * @param rawBaseUrl - The raw value from the request body (`undefined` = not sent).
  * @param existingBaseUrl - The current `baseUrl` stored in the DB.
@@ -125,8 +144,9 @@ function normalizeBaseUrl(
   rawBaseUrl: string | undefined,
   existingBaseUrl: string | null,
 ): NormalizedBaseUrl {
+  const trimmed = rawBaseUrl?.trim();
   const toStore: string | null | undefined =
-    (mode === "optional" && rawBaseUrl?.trim() === "") ? null : rawBaseUrl;
+    (mode === "optional" && trimmed === "") ? null : trimmed;
 
   let forAdapter: string | undefined;
   if (toStore !== undefined) {
@@ -186,17 +206,15 @@ export async function PATCH(req: NextRequest, { params }: RouteContext) {
   const { displayName, baseUrl: rawBaseUrl, changeCredentials, credentials } = parsed;
 
   const metadata = getProviderMetadata(provider.type);
+
   const { toStore: normalizedBaseUrl, forAdapter: adapterBaseUrl } = normalizeBaseUrl(
     metadata?.baseUrlMode,
     rawBaseUrl,
     provider.baseUrl,
   );
 
-  // Validate baseUrl for providers that require it
-  if (metadata?.baseUrlMode === "required" && !normalizedBaseUrl) { return fail("MISSING_FIELDS", 400); }
-
-  // Validate baseUrl format if a non-empty value is provided
-  if (normalizedBaseUrl && !isValidBaseUrl(normalizedBaseUrl)) { return fail("INVALID_BASE_URL", 400); }
+  const baseUrlError = validateBaseUrlRequest(rawBaseUrl, metadata?.baseUrlMode, normalizedBaseUrl);
+  if (baseUrlError) { return baseUrlError; }
 
   // Determine the effective credentials for connection test
   const credResult = resolveCredentials(provider, changeCredentials, credentials, adapterBaseUrl);

--- a/src/app/api/providers/[id]/route.ts
+++ b/src/app/api/providers/[id]/route.ts
@@ -125,8 +125,16 @@ function normalizeBaseUrl(
   rawBaseUrl: string | undefined,
   existingBaseUrl: string | null,
 ): NormalizedBaseUrl {
-  const toStore: string | null | undefined = (mode === "optional" && rawBaseUrl?.trim() === "") ? null : rawBaseUrl;
-  const forAdapter: string | undefined = toStore !== undefined ? (toStore ?? undefined) : (existingBaseUrl ?? undefined);
+  const toStore: string | null | undefined =
+    (mode === "optional" && rawBaseUrl?.trim() === "") ? null : rawBaseUrl;
+
+  let forAdapter: string | undefined;
+  if (toStore !== undefined) {
+    forAdapter = toStore ?? undefined;
+  } else {
+    forAdapter = existingBaseUrl ?? undefined;
+  }
+
   return { toStore, forAdapter };
 }
 

--- a/src/app/api/providers/[id]/route.ts
+++ b/src/app/api/providers/[id]/route.ts
@@ -1,3 +1,4 @@
+/** API routes for single provider CRUD (GET, PATCH, DELETE). */
 import type { NextRequest } from "next/server";
 
 import { ok, fail, failWithDetails } from "@/lib/api/api-response";
@@ -9,6 +10,31 @@ import { createConnectionTestErrorDetails } from "@/lib/sync/error-utils";
 import { isValidBaseUrl } from "@/lib/validation/base-url";
 import { createAdapter, getProviderIconUrl } from "@/services/issue-provider/factory";
 import { getProviderMetadata } from "@/services/issue-provider/registry";
+
+/**
+ * Validates the PATCH request body shape.
+ * @param body - The parsed JSON body to validate.
+ * @returns The validated and typed body, or `null` if invalid.
+ */
+function validatePatchBody(body: unknown): {
+  displayName: string;
+  baseUrl?: string;
+  changeCredentials: boolean;
+  credentials?: Record<string, string>;
+} | null {
+  if (typeof body !== "object" || body === null) { return null; }
+  const obj = body as Record<string, unknown>;
+  if (typeof obj.displayName !== "string" || obj.displayName.length < 1) { return null; }
+  if (typeof obj.changeCredentials !== "boolean") { return null; }
+  if (obj.baseUrl !== undefined && typeof obj.baseUrl !== "string") { return null; }
+  if (obj.credentials !== undefined && typeof obj.credentials !== "object") { return null; }
+  return {
+    displayName: obj.displayName,
+    baseUrl: obj.baseUrl as string | undefined,
+    changeCredentials: obj.changeCredentials,
+    credentials: obj.credentials as Record<string, string> | undefined,
+  };
+}
 
 type RouteContext = { params: Promise<{ id: string }> };
 
@@ -120,7 +146,12 @@ export async function DELETE(req: NextRequest, { params }: RouteContext) {
 
   if (!provider) { return fail("FORBIDDEN", 403); }
 
-  await prisma.issueProvider.delete({ where: { id } });
+  try {
+    await prisma.issueProvider.delete({ where: { id } });
+  } catch (error) {
+    console.error("[provider] Failed to delete provider:", error instanceof Error ? error.message : String(error));
+    return fail("INTERNAL_ERROR", 500);
+  }
 
   return ok({ id });
 }
@@ -142,12 +173,9 @@ export async function PATCH(req: NextRequest, { params }: RouteContext) {
   const body = await req.json().catch(() => null);
   if (!body) { return fail("INVALID_BODY", 400); }
 
-  const { displayName, baseUrl: rawBaseUrl, changeCredentials, credentials } = body as {
-    displayName: string;
-    baseUrl?: string;
-    changeCredentials: boolean;
-    credentials?: Record<string, string>;
-  };
+  const parsed = validatePatchBody(body);
+  if (!parsed) { return fail("INVALID_BODY", 400); }
+  const { displayName, baseUrl: rawBaseUrl, changeCredentials, credentials } = parsed;
 
   const metadata = getProviderMetadata(provider.type);
   const { toStore: normalizedBaseUrl, forAdapter: adapterBaseUrl } = normalizeBaseUrl(
@@ -155,9 +183,6 @@ export async function PATCH(req: NextRequest, { params }: RouteContext) {
     rawBaseUrl,
     provider.baseUrl,
   );
-
-  // Validate displayName
-  if (!displayName) { return fail("MISSING_FIELDS", 400); }
 
   // Validate baseUrl for providers that require it
   if (metadata?.baseUrlMode === "required" && !normalizedBaseUrl) { return fail("MISSING_FIELDS", 400); }

--- a/src/app/api/providers/[id]/route.ts
+++ b/src/app/api/providers/[id]/route.ts
@@ -6,6 +6,7 @@ import { prisma } from "@/lib/db/db";
 import { buildTypedCredentials } from "@/lib/encryption/credentials";
 import { encrypt, decrypt } from "@/lib/encryption/encryption";
 import { createConnectionTestErrorDetails } from "@/lib/sync/error-utils";
+import { isValidBaseUrl } from "@/lib/validation/base-url";
 import { createAdapter, getProviderIconUrl } from "@/services/issue-provider/factory";
 import { getProviderMetadata } from "@/services/issue-provider/registry";
 
@@ -79,6 +80,30 @@ function resolveCredentials(
   };
 }
 
+type NormalizedBaseUrl = {
+  /** URL to write to the DB: `null` = clear, `undefined` = no change, `string` = new URL. */
+  toStore: string | null | undefined;
+  /** URL to pass to the adapter for the connection test (`undefined` = use SaaS default). */
+  forAdapter: string | undefined;
+};
+
+/**
+ * Normalises the raw `baseUrl` from a PATCH request body.
+ * @param mode - The provider's `baseUrlMode` (`"optional"`, `"required"`, or `"none"`).
+ * @param rawBaseUrl - The raw value from the request body (`undefined` = not sent).
+ * @param existingBaseUrl - The current `baseUrl` stored in the DB.
+ * @returns Normalised values for the DB update and adapter instantiation.
+ */
+function normalizeBaseUrl(
+  mode: string | undefined,
+  rawBaseUrl: string | undefined,
+  existingBaseUrl: string | null,
+): NormalizedBaseUrl {
+  const toStore: string | null | undefined = (mode === "optional" && rawBaseUrl?.trim() === "") ? null : rawBaseUrl;
+  const forAdapter: string | undefined = toStore !== undefined ? (toStore ?? undefined) : (existingBaseUrl ?? undefined);
+  return { toStore, forAdapter };
+}
+
 /**
  * DELETE /api/providers/[id] — Deletes an issue provider owned by the authenticated user.
  */
@@ -125,25 +150,30 @@ export async function PATCH(req: NextRequest, { params }: RouteContext) {
   };
 
   const metadata = getProviderMetadata(provider.type);
-  const baseUrl = (metadata?.baseUrlMode === "optional" && rawBaseUrl?.trim() === "")
-    ? undefined
-    : rawBaseUrl;
+  const { toStore: normalizedBaseUrl, forAdapter: adapterBaseUrl } = normalizeBaseUrl(
+    metadata?.baseUrlMode,
+    rawBaseUrl,
+    provider.baseUrl,
+  );
 
   // Validate displayName
   if (!displayName) { return fail("MISSING_FIELDS", 400); }
 
   // Validate baseUrl for providers that require it
-  if (metadata?.baseUrlMode === "required" && !baseUrl) { return fail("MISSING_FIELDS", 400); }
+  if (metadata?.baseUrlMode === "required" && !normalizedBaseUrl) { return fail("MISSING_FIELDS", 400); }
+
+  // Validate baseUrl format if a non-empty value is provided
+  if (normalizedBaseUrl && !isValidBaseUrl(normalizedBaseUrl)) { return fail("INVALID_BASE_URL", 400); }
 
   // Determine the effective credentials for connection test
-  const credResult = resolveCredentials(provider, changeCredentials, credentials, baseUrl);
+  const credResult = resolveCredentials(provider, changeCredentials, credentials, adapterBaseUrl);
   if (credResult instanceof Response) { return credResult; }
   const { encryptedToStore, effectiveCredentials } = credResult;
 
   // Test connection
   try {
     const typedCredentials = buildTypedCredentials(provider.type, effectiveCredentials);
-    const adapter = createAdapter(provider.type, typedCredentials, baseUrl || provider.baseUrl);
+    const adapter = createAdapter(provider.type, typedCredentials, adapterBaseUrl);
     await adapter.testConnection();
   } catch (error) {
     console.error("[provider] Connection test failed:", error instanceof Error ? error.message : String(error));
@@ -157,7 +187,7 @@ export async function PATCH(req: NextRequest, { params }: RouteContext) {
       where: { id },
       data: {
         displayName,
-        ...(baseUrl !== undefined ? { baseUrl } : {}),
+        ...(rawBaseUrl !== undefined ? { baseUrl: normalizedBaseUrl } : {}),
         ...(encryptedToStore ? { encryptedCredentials: encryptedToStore } : {}),
       },
       select: { id: true, type: true, displayName: true, baseUrl: true, createdAt: true },

--- a/src/app/api/providers/route.ts
+++ b/src/app/api/providers/route.ts
@@ -6,6 +6,7 @@ import { prisma } from "@/lib/db/db";
 import { buildTypedCredentials } from "@/lib/encryption/credentials";
 import { encrypt } from "@/lib/encryption/encryption";
 import { createConnectionTestErrorDetails } from "@/lib/sync/error-utils";
+import { isValidBaseUrl } from "@/lib/validation/base-url";
 import { createAdapter, getProviderIconUrl } from "@/services/issue-provider/factory";
 import { getAllProviders } from "@/services/issue-provider/registry";
 
@@ -49,8 +50,13 @@ export async function POST(req: NextRequest) {
     return fail("INVALID_PROVIDER_TYPE", 400);
   }
 
-  // Extract baseUrl from credentials for Jira/Redmine (stored separately in DB)
+  // Extract baseUrl from credentials (stored separately in DB, not encrypted)
   const { baseUrl, ...credentialsWithoutUrl } = credentials as Record<string, string>;
+
+  // Validate baseUrl format if provided
+  if (baseUrl && !isValidBaseUrl(baseUrl)) {
+    return fail("INVALID_BASE_URL", 400);
+  }
 
   // Test connection before saving (pass full credentials including baseUrl to adapter)
   try {

--- a/src/app/api/providers/route.ts
+++ b/src/app/api/providers/route.ts
@@ -33,6 +33,27 @@ export async function GET() {
   return ok(providers.map((p) => ({ ...p, iconUrl: getProviderIconUrl(p.type) })));
 }
 
+type PostBody = {
+  type: string;
+  displayName: string;
+  credentials: Record<string, string>;
+};
+
+/**
+ * Validates the POST /api/providers request body shape.
+ * @param body - The parsed JSON body to validate.
+ * @returns The validated body, or `null` if the shape is invalid.
+ */
+function parsePostBody(body: unknown): PostBody | null {
+  if (typeof body !== "object" || body === null) { return null; }
+  const obj = body as Record<string, unknown>;
+  if (!obj.type || typeof obj.type !== "string") { return null; }
+  if (!obj.displayName || typeof obj.displayName !== "string") { return null; }
+  const creds = obj.credentials;
+  if (!creds || typeof creds !== "object" || Array.isArray(creds)) { return null; }
+  return { type: obj.type, displayName: obj.displayName, credentials: creds as Record<string, string> };
+}
+
 /**
  * POST /api/providers — Creates a new issue provider after verifying the connection.
  */
@@ -40,25 +61,19 @@ export async function POST(req: NextRequest) {
   const session = await auth();
   if (!session) { return fail("UNAUTHORIZED", 401); }
 
-  const body = await req.json().catch(() => null);
-  if (!body) { return fail("INVALID_BODY", 400); }
+  const rawBody = await req.json().catch(() => null);
+  const parsed = parsePostBody(rawBody);
+  if (!parsed) { return fail("INVALID_BODY", 400); }
 
-  const { type, displayName, credentials } = body as {
-    type: string;
-    displayName: string;
-    credentials: Record<string, string>;
-  };
-
-  if (!type || !displayName || !credentials) {
-    return fail("MISSING_FIELDS", 400);
-  }
+  const { type, displayName, credentials } = parsed;
 
   if (!getAllProviders().some((m) => m.type === type)) {
     return fail("INVALID_PROVIDER_TYPE", 400);
   }
 
-  // Extract baseUrl from credentials (stored separately in DB, not encrypted)
-  const { baseUrl, ...credentialsWithoutUrl } = credentials as Record<string, string>;
+  // Extract and trim baseUrl from credentials (stored separately in DB, not encrypted)
+  const { baseUrl: rawBaseUrl, ...credentialsWithoutUrl } = credentials as Record<string, string>;
+  const baseUrl = rawBaseUrl?.trim() || undefined;
 
   // Validate baseUrl format if provided
   if (baseUrl && !isValidBaseUrl(baseUrl)) {

--- a/src/app/api/providers/route.ts
+++ b/src/app/api/providers/route.ts
@@ -1,3 +1,4 @@
+/** API routes for listing and creating providers (GET, POST). */
 import type { NextRequest } from "next/server";
 
 import { ok, fail, failWithDetails } from "@/lib/api/api-response";
@@ -17,11 +18,17 @@ export async function GET() {
   const session = await auth();
   if (!session) { return fail("UNAUTHORIZED", 401); }
 
-  const providers = await prisma.issueProvider.findMany({
-    where: { userId: session.user.id },
-    select: { id: true, type: true, displayName: true, baseUrl: true, createdAt: true },
-    orderBy: { createdAt: "asc" },
-  });
+  let providers;
+  try {
+    providers = await prisma.issueProvider.findMany({
+      where: { userId: session.user.id },
+      select: { id: true, type: true, displayName: true, baseUrl: true, createdAt: true },
+      orderBy: { createdAt: "asc" },
+    });
+  } catch (error) {
+    console.error("[provider] Failed to list providers:", error instanceof Error ? error.message : String(error));
+    return fail("INTERNAL_ERROR", 500);
+  }
 
   return ok(providers.map((p) => ({ ...p, iconUrl: getProviderIconUrl(p.type) })));
 }

--- a/src/components/providers/ProviderEditModal.tsx
+++ b/src/components/providers/ProviderEditModal.tsx
@@ -1,3 +1,4 @@
+/** Modal dialog for editing an existing issue provider's display name, base URL, or credentials. */
 "use client";
 
 import {
@@ -20,14 +21,8 @@ import { useTranslations } from "next-intl";
 import { type FormEvent, useState } from "react";
 
 import { formatProviderApiError, type ProviderApiErrorResponse } from "@/lib/sync/error-utils";
-import { isValidBaseUrl } from "@/lib/validation/base-url";
+import { getBaseUrlValidationError, isValidBaseUrl } from "@/lib/validation/base-url";
 import { getProviderMetadata } from "@/services/issue-provider/registry";
-
-/** Returns a validation error message when baseUrl is enabled and malformed, or null when valid. */
-function getBaseUrlError(enabled: boolean, touched: boolean, value: string, errorMsg: string): string | null {
-  if (!enabled || !touched || !value) { return null; }
-  return isValidBaseUrl(value) ? null : errorMsg;
-}
 
 /** Builds the PATCH request body for the provider update. */
 function buildPatchBody(
@@ -93,7 +88,7 @@ export default function ProviderEditModal({
   const [error, setError] = useState<string | null>(null);
 
   const baseUrlEnabled = isRequired || (isOptional && useCustomBaseUrl);
-  const baseUrlError = getBaseUrlError(baseUrlEnabled, baseUrlTouched, baseUrl, t("fields.invalidBaseUrl"));
+  const baseUrlError = getBaseUrlValidationError(baseUrlEnabled, baseUrlTouched, baseUrl, t("fields.invalidBaseUrl"));
 
   /** Updates a single credential field. */
   function handleCredentialChange(key: string, value: string) {

--- a/src/components/providers/ProviderEditModal.tsx
+++ b/src/components/providers/ProviderEditModal.tsx
@@ -118,8 +118,8 @@ export default function ProviderEditModal({
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
 
-    // Block submission if baseUrl is enabled but invalid
-    if (baseUrlEnabled && baseUrl && !isValidBaseUrl(baseUrl)) {
+    // Block submission if baseUrl is enabled but empty or invalid
+    if (baseUrlEnabled && (!baseUrl || !isValidBaseUrl(baseUrl))) {
       setBaseUrlTouched(true);
       return;
     }
@@ -196,7 +196,7 @@ export default function ProviderEditModal({
                   value={baseUrl}
                   onChange={(e) => setBaseUrl(e.target.value)}
                   onBlur={() => setBaseUrlTouched(true)}
-                  required={isRequired}
+                  required={baseUrlEnabled}
                   disabled={isOptional && !useCustomBaseUrl}
                   fullWidth
                   error={Boolean(baseUrlError)}

--- a/src/components/providers/ProviderEditModal.tsx
+++ b/src/components/providers/ProviderEditModal.tsx
@@ -24,16 +24,26 @@ import { formatProviderApiError, type ProviderApiErrorResponse } from "@/lib/syn
 import { getBaseUrlValidationError, isValidBaseUrl } from "@/lib/validation/base-url";
 import { getProviderMetadata } from "@/services/issue-provider/registry";
 
+interface BuildPatchBodyArgs {
+  displayName: string;
+  changeCredentials: boolean;
+  credentials: Record<string, string>;
+  isRequired: boolean;
+  isOptional: boolean;
+  useCustomBaseUrl: boolean;
+  baseUrl: string;
+}
+
 /** Builds the PATCH request body for the provider update. */
-function buildPatchBody(
-  displayName: string,
-  changeCredentials: boolean,
-  credentials: Record<string, string>,
-  isRequired: boolean,
-  isOptional: boolean,
-  useCustomBaseUrl: boolean,
-  baseUrl: string,
-): Record<string, unknown> {
+export function buildPatchBody({
+  displayName,
+  changeCredentials,
+  credentials,
+  isRequired,
+  isOptional,
+  useCustomBaseUrl,
+  baseUrl,
+}: BuildPatchBodyArgs): Record<string, unknown> {
   const body: Record<string, unknown> = { displayName, changeCredentials };
   if (isRequired) {
     body.baseUrl = baseUrl;
@@ -118,7 +128,7 @@ export default function ProviderEditModal({
     setError(null);
 
     try {
-      const body = buildPatchBody(displayName, changeCredentials, credentials, isRequired, isOptional, useCustomBaseUrl, baseUrl);
+      const body = buildPatchBody({ displayName, changeCredentials, credentials, isRequired, isOptional, useCustomBaseUrl, baseUrl });
 
       const res = await fetch(`/api/providers/${provider.id}`, {
         method: "PATCH",

--- a/src/components/providers/ProviderEditModal.tsx
+++ b/src/components/providers/ProviderEditModal.tsx
@@ -7,9 +7,11 @@ import {
   DialogContent,
   DialogActions,
   Button,
-  TextField,
   Checkbox,
+  FormControl,
   FormControlLabel,
+  FormHelperText,
+  TextField,
   Alert,
   Stack,
   CircularProgress,
@@ -18,7 +20,36 @@ import { useTranslations } from "next-intl";
 import { type FormEvent, useState } from "react";
 
 import { formatProviderApiError, type ProviderApiErrorResponse } from "@/lib/sync/error-utils";
+import { isValidBaseUrl } from "@/lib/validation/base-url";
 import { getProviderMetadata } from "@/services/issue-provider/registry";
+
+/** Returns a validation error message when baseUrl is enabled and malformed, or null when valid. */
+function getBaseUrlError(enabled: boolean, touched: boolean, value: string, errorMsg: string): string | null {
+  if (!enabled || !touched || !value) { return null; }
+  return isValidBaseUrl(value) ? null : errorMsg;
+}
+
+/** Builds the PATCH request body for the provider update. */
+function buildPatchBody(
+  displayName: string,
+  changeCredentials: boolean,
+  credentials: Record<string, string>,
+  isRequired: boolean,
+  isOptional: boolean,
+  useCustomBaseUrl: boolean,
+  baseUrl: string,
+): Record<string, unknown> {
+  const body: Record<string, unknown> = { displayName, changeCredentials };
+  if (isRequired) {
+    body.baseUrl = baseUrl;
+  } else if (isOptional) {
+    body.baseUrl = useCustomBaseUrl ? baseUrl : "";
+  }
+  if (changeCredentials) {
+    body.credentials = credentials;
+  }
+  return body;
+}
 
 interface Provider {
   id: string;
@@ -47,35 +78,52 @@ export default function ProviderEditModal({
   const tSync = useTranslations("sync");
 
   const metadata = getProviderMetadata(provider.type);
+  const isOptional = metadata?.baseUrlMode === "optional";
+  const isRequired = metadata?.baseUrlMode === "required";
+  const showBaseUrlField = isRequired || isOptional;
 
   const [displayName, setDisplayName] = useState(provider.displayName);
+  // For optional providers, checkbox is ON when provider.baseUrl is non-null
+  const [useCustomBaseUrl, setUseCustomBaseUrl] = useState(isOptional ? Boolean(provider.baseUrl) : false);
   const [baseUrl, setBaseUrl] = useState(provider.baseUrl ?? "");
+  const [baseUrlTouched, setBaseUrlTouched] = useState(false);
   const [changeCredentials, setChangeCredentials] = useState(false);
   const [credentials, setCredentials] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const baseUrlEnabled = isRequired || (isOptional && useCustomBaseUrl);
+  const baseUrlError = getBaseUrlError(baseUrlEnabled, baseUrlTouched, baseUrl, t("fields.invalidBaseUrl"));
 
   /** Updates a single credential field. */
   function handleCredentialChange(key: string, value: string) {
     setCredentials((prev) => ({ ...prev, [key]: value }));
   }
 
+  /** Toggles the custom base URL checkbox. */
+  function handleToggleCustomBaseUrl(checked: boolean) {
+    setUseCustomBaseUrl(checked);
+    if (!checked) {
+      setBaseUrl("");
+      setBaseUrlTouched(false);
+    }
+  }
+
   /** Submits the provider update form. */
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
+
+    // Block submission if baseUrl is enabled but invalid
+    if (baseUrlEnabled && baseUrl && !isValidBaseUrl(baseUrl)) {
+      setBaseUrlTouched(true);
+      return;
+    }
+
     setLoading(true);
     setError(null);
 
     try {
-      const body: Record<string, unknown> = { displayName, changeCredentials };
-      if (metadata?.baseUrlMode === "required") {
-        body.baseUrl = baseUrl;
-      } else if (metadata?.baseUrlMode === "optional" && baseUrl.trim() !== "") {
-        body.baseUrl = baseUrl;
-      }
-      if (changeCredentials) {
-        body.credentials = credentials;
-      }
+      const body = buildPatchBody(displayName, changeCredentials, credentials, isRequired, isOptional, useCustomBaseUrl, baseUrl);
 
       const res = await fetch(`/api/providers/${provider.id}`, {
         method: "PATCH",
@@ -124,14 +172,32 @@ export default function ProviderEditModal({
               fullWidth
             />
 
-            {metadata && metadata.baseUrlMode !== "none" && (
-              <TextField
-                label={t("fields.baseUrl")}
-                value={baseUrl}
-                onChange={(e) => setBaseUrl(e.target.value)}
-                required={metadata.baseUrlMode === "required"}
-                fullWidth
+            {showBaseUrlField && isOptional && (
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={useCustomBaseUrl}
+                    onChange={(e) => handleToggleCustomBaseUrl(e.target.checked)}
+                  />
+                }
+                label={t("fields.useCustomBaseUrl")}
               />
+            )}
+
+            {showBaseUrlField && (
+              <FormControl fullWidth error={Boolean(baseUrlError)}>
+                <TextField
+                  label={t("fields.baseUrl")}
+                  value={baseUrl}
+                  onChange={(e) => setBaseUrl(e.target.value)}
+                  onBlur={() => setBaseUrlTouched(true)}
+                  required={isRequired}
+                  disabled={isOptional && !useCustomBaseUrl}
+                  fullWidth
+                  error={Boolean(baseUrlError)}
+                />
+                {baseUrlError && <FormHelperText>{baseUrlError}</FormHelperText>}
+              </FormControl>
             )}
 
             <FormControlLabel

--- a/src/components/providers/ProviderForm.tsx
+++ b/src/components/providers/ProviderForm.tsx
@@ -1,3 +1,4 @@
+/** Form for creating a new issue provider, with provider-type selection and credential fields. */
 "use client";
 
 import {
@@ -18,14 +19,8 @@ import {
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 
-import { isValidBaseUrl } from "@/lib/validation/base-url";
+import { getBaseUrlValidationError, isValidBaseUrl } from "@/lib/validation/base-url";
 import { getAllProviders } from "@/services/issue-provider/registry";
-
-/** Returns a validation error message when baseUrl is enabled and malformed, or null when valid. */
-function getBaseUrlError(enabled: boolean, touched: boolean, value: string, errorMsg: string): string | null {
-  if (!enabled || !touched || !value) { return null; }
-  return isValidBaseUrl(value) ? null : errorMsg;
-}
 
 /** Removes the `baseUrl` key from a credentials object immutably. */
 function withoutBaseUrl(creds: Record<string, string>): Record<string, string> {
@@ -66,7 +61,7 @@ export default function ProviderForm({ onSubmit }: ProviderFormProps) {
   const showBaseUrlField = isRequired || isOptional;
   const baseUrlEnabled = isRequired || (isOptional && useCustomBaseUrl);
   const baseUrlValue = credentials.baseUrl ?? "";
-  const baseUrlError = getBaseUrlError(baseUrlEnabled, baseUrlTouched, baseUrlValue, t("fields.invalidBaseUrl"));
+  const baseUrlError = getBaseUrlValidationError(baseUrlEnabled, baseUrlTouched, baseUrlValue, t("fields.invalidBaseUrl"));
 
   /** Updates a single credential field. */
   function handleCredentialChange(key: string, value: string) {

--- a/src/components/providers/ProviderForm.tsx
+++ b/src/components/providers/ProviderForm.tsx
@@ -90,8 +90,8 @@ export default function ProviderForm({ onSubmit }: ProviderFormProps) {
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
 
-    // Block submission if baseUrl is enabled but invalid
-    if (baseUrlEnabled && baseUrlValue && !isValidBaseUrl(baseUrlValue)) {
+    // Block submission if baseUrl is enabled but empty or invalid
+    if (baseUrlEnabled && (!baseUrlValue || !isValidBaseUrl(baseUrlValue))) {
       setBaseUrlTouched(true);
       return;
     }
@@ -177,11 +177,11 @@ export default function ProviderForm({ onSubmit }: ProviderFormProps) {
           <FormControl fullWidth error={Boolean(baseUrlError)}>
             <TextField
               label={t("fields.baseUrl")}
-              placeholder={isOptional ? "https://github.example.com" : "https://your-domain.example.com"}
+              placeholder="https://your-domain.example.com"
               value={baseUrlValue}
               onChange={(e) => handleCredentialChange("baseUrl", e.target.value)}
               onBlur={() => setBaseUrlTouched(true)}
-              required={isRequired}
+              required={baseUrlEnabled}
               disabled={isOptional && !useCustomBaseUrl}
               fullWidth
               error={Boolean(baseUrlError)}

--- a/src/components/providers/ProviderForm.tsx
+++ b/src/components/providers/ProviderForm.tsx
@@ -3,7 +3,10 @@
 import {
   Box,
   Button,
+  Checkbox,
   FormControl,
+  FormControlLabel,
+  FormHelperText,
   InputLabel,
   MenuItem,
   Select,
@@ -15,7 +18,20 @@ import {
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 
+import { isValidBaseUrl } from "@/lib/validation/base-url";
 import { getAllProviders } from "@/services/issue-provider/registry";
+
+/** Returns a validation error message when baseUrl is enabled and malformed, or null when valid. */
+function getBaseUrlError(enabled: boolean, touched: boolean, value: string, errorMsg: string): string | null {
+  if (!enabled || !touched || !value) { return null; }
+  return isValidBaseUrl(value) ? null : errorMsg;
+}
+
+/** Removes the `baseUrl` key from a credentials object immutably. */
+function withoutBaseUrl(creds: Record<string, string>): Record<string, string> {
+  const { baseUrl: _removed, ...rest } = creds;
+  return rest;
+}
 
 /** Data shape submitted by {@link ProviderForm}. */
 export interface ProviderFormData {
@@ -39,10 +55,18 @@ export default function ProviderForm({ onSubmit }: ProviderFormProps) {
   const [type, setType] = useState<string>(firstType);
   const [displayName, setDisplayName] = useState("");
   const [credentials, setCredentials] = useState<Record<string, string>>({});
+  const [useCustomBaseUrl, setUseCustomBaseUrl] = useState(false);
+  const [baseUrlTouched, setBaseUrlTouched] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const selectedMeta = providers.find((p) => p.type === type);
+  const isOptional = selectedMeta?.baseUrlMode === "optional";
+  const isRequired = selectedMeta?.baseUrlMode === "required";
+  const showBaseUrlField = isRequired || isOptional;
+  const baseUrlEnabled = isRequired || (isOptional && useCustomBaseUrl);
+  const baseUrlValue = credentials.baseUrl ?? "";
+  const baseUrlError = getBaseUrlError(baseUrlEnabled, baseUrlTouched, baseUrlValue, t("fields.invalidBaseUrl"));
 
   /** Updates a single credential field. */
   function handleCredentialChange(key: string, value: string) {
@@ -53,12 +77,30 @@ export default function ProviderForm({ onSubmit }: ProviderFormProps) {
   function handleTypeChange(newType: string) {
     setType(newType);
     setCredentials({});
+    setUseCustomBaseUrl(false);
+    setBaseUrlTouched(false);
     setError(null);
+  }
+
+  /** Toggles the custom base URL checkbox. */
+  function handleToggleCustomBaseUrl(checked: boolean) {
+    setUseCustomBaseUrl(checked);
+    if (!checked) {
+      setCredentials((prev) => withoutBaseUrl(prev));
+      setBaseUrlTouched(false);
+    }
   }
 
   /** Submits the new provider form. */
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+
+    // Block submission if baseUrl is enabled but invalid
+    if (baseUrlEnabled && baseUrlValue && !isValidBaseUrl(baseUrlValue)) {
+      setBaseUrlTouched(true);
+      return;
+    }
+
     setLoading(true);
     setError(null);
 
@@ -66,6 +108,7 @@ export default function ProviderForm({ onSubmit }: ProviderFormProps) {
       await onSubmit({ type, displayName, credentials });
       setDisplayName("");
       setCredentials({});
+      setUseCustomBaseUrl(false);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       setError(msg);
@@ -123,15 +166,33 @@ export default function ProviderForm({ onSubmit }: ProviderFormProps) {
           slotProps={{ htmlInput: { "data-testid": "provider-name-input" } }}
         />
 
-        {selectedMeta && selectedMeta.baseUrlMode !== "none" && (
-          <TextField
-            label={t("fields.baseUrl")}
-            placeholder={selectedMeta.baseUrlMode === "optional" ? "https://gitlab.com" : "https://your-domain.example.com"}
-            value={credentials.baseUrl ?? ""}
-            onChange={(e) => handleCredentialChange("baseUrl", e.target.value)}
-            required={selectedMeta.baseUrlMode === "required"}
-            fullWidth
+        {showBaseUrlField && isOptional && (
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={useCustomBaseUrl}
+                onChange={(e) => handleToggleCustomBaseUrl(e.target.checked)}
+              />
+            }
+            label={t("fields.useCustomBaseUrl")}
           />
+        )}
+
+        {showBaseUrlField && (
+          <FormControl fullWidth error={Boolean(baseUrlError)}>
+            <TextField
+              label={t("fields.baseUrl")}
+              placeholder={isOptional ? "https://github.example.com" : "https://your-domain.example.com"}
+              value={baseUrlValue}
+              onChange={(e) => handleCredentialChange("baseUrl", e.target.value)}
+              onBlur={() => setBaseUrlTouched(true)}
+              required={isRequired}
+              disabled={isOptional && !useCustomBaseUrl}
+              fullWidth
+              error={Boolean(baseUrlError)}
+            />
+            {baseUrlError && <FormHelperText>{baseUrlError}</FormHelperText>}
+          </FormControl>
         )}
 
         {selectedMeta?.credentialFields.map((field) => (

--- a/src/lib/validation/base-url.ts
+++ b/src/lib/validation/base-url.ts
@@ -1,0 +1,64 @@
+/**
+ * Validates that a URL is an absolute URL with an http or https scheme and a non-empty host.
+ * Used to validate optional base URLs for self-hosted / Enterprise provider instances.
+ *
+ * Security: rejects private/loopback/link-local IP ranges and URLs with embedded credentials
+ * to mitigate Server-Side Request Forgery (SSRF). This is a synchronous string-based check;
+ * it does NOT perform DNS resolution, so hostnames that resolve to private IPs at runtime are
+ * not blocked here. The connection test in the API route handles unreachable hosts.
+ *
+ * @param url - The URL string to validate.
+ * @returns `true` if the URL is a valid, public-looking http/https absolute URL; `false` otherwise.
+ */
+export function isValidBaseUrl(url: string): boolean {
+  if (!url) { return false; }
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") { return false; }
+  if (!parsed.hostname) { return false; }
+
+  // Reject embedded credentials — these are a SSRF/credential-leakage vector.
+  if (parsed.username || parsed.password) { return false; }
+
+  // Strip IPv6 brackets before pattern-matching (e.g. "[::1]" → "::1").
+  const host = parsed.hostname.replace(/^\[|\]$/g, "").toLowerCase();
+
+  // Reject loopback, private, and link-local addresses (RFC 1122 / RFC 1918 / RFC 3927).
+  if (isPrivateHost(host)) { return false; }
+
+  return true;
+}
+
+/**
+ * Returns `true` when `host` (already lower-cased, brackets stripped) is a loopback,
+ * private-range, or link-local address that must not be reached from the server.
+ * @param host - Lower-cased hostname or IP address (IPv6 brackets already removed).
+ */
+function isPrivateHost(host: string): boolean {
+  if (host === "localhost") { return true; }
+  if (host === "0.0.0.0") { return true; }
+
+  // IPv6 loopback and private ranges.
+  if (host === "::1") { return true; }
+  if (host.startsWith("::ffff:127.")) { return true; } // IPv4-mapped loopback
+  if (/^fc[0-9a-f]{2}:/i.test(host)) { return true; } // Unique local (fc00::/7)
+  if (/^fe[89ab][0-9a-f]:/i.test(host)) { return true; } // Link-local (fe80::/10)
+
+  // IPv4 loopback (127.0.0.0/8).
+  if (/^127\.\d+\.\d+\.\d+$/.test(host)) { return true; }
+
+  // IPv4 link-local / APIPA (169.254.0.0/16).
+  if (/^169\.254\.\d+\.\d+$/.test(host)) { return true; }
+
+  // RFC 1918 private ranges.
+  if (/^10\.\d+\.\d+\.\d+$/.test(host)) { return true; }
+  if (/^192\.168\.\d+\.\d+$/.test(host)) { return true; }
+  if (/^172\.(1[6-9]|2\d|3[01])\.\d+\.\d+$/.test(host)) { return true; }
+
+  return false;
+}

--- a/src/lib/validation/base-url.ts
+++ b/src/lib/validation/base-url.ts
@@ -1,4 +1,22 @@
 /**
+ * Returns a validation error message when baseUrl is enabled and malformed, or null when valid.
+ * @param enabled - Whether the baseUrl field is active (required mode, or optional mode with checkbox on).
+ * @param touched - Whether the field has been blurred at least once.
+ * @param value - The current baseUrl value.
+ * @param errorMsg - The error message to return when validation fails.
+ * @returns The error message string, or `null` when the field is valid or should not be validated.
+ */
+export function getBaseUrlValidationError(
+  enabled: boolean,
+  touched: boolean,
+  value: string,
+  errorMsg: string,
+): string | null {
+  if (!enabled || !touched || !value) { return null; }
+  return isValidBaseUrl(value) ? null : errorMsg;
+}
+
+/**
  * Validates that a URL is an absolute URL with an http or https scheme and a non-empty host.
  * Used to validate optional base URLs for self-hosted / Enterprise provider instances.
  *

--- a/src/lib/validation/base-url.ts
+++ b/src/lib/validation/base-url.ts
@@ -1,5 +1,6 @@
 /**
- * Returns a validation error message when baseUrl is enabled and malformed, or null when valid.
+ * Returns a validation error message when baseUrl is enabled, touched, and empty or malformed.
+ * Returns `null` when the field is disabled, untouched, or contains a valid URL.
  * @param enabled - Whether the baseUrl field is active (required mode, or optional mode with checkbox on).
  * @param touched - Whether the field has been blurred at least once.
  * @param value - The current baseUrl value.
@@ -12,8 +13,8 @@ export function getBaseUrlValidationError(
   value: string,
   errorMsg: string,
 ): string | null {
-  if (!enabled || !touched || !value) { return null; }
-  return isValidBaseUrl(value) ? null : errorMsg;
+  if (!enabled || !touched) { return null; }
+  return value && isValidBaseUrl(value) ? null : errorMsg;
 }
 
 /**
@@ -64,7 +65,7 @@ function isPrivateHost(host: string): boolean {
   // IPv6 loopback and private ranges.
   if (host === "::1") { return true; }
   if (host.startsWith("::ffff:127.")) { return true; } // IPv4-mapped loopback
-  if (/^fc[0-9a-f]{2}:/i.test(host)) { return true; } // Unique local (fc00::/7)
+  if (/^f[cd][0-9a-f]{2}:/i.test(host)) { return true; } // Unique local (fc00::/7, covers fc.. and fd..)
   if (/^fe[89ab][0-9a-f]:/i.test(host)) { return true; } // Link-local (fe80::/10)
 
   // IPv4 loopback (127.0.0.0/8).

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -84,7 +84,9 @@
       "baseUrl": "Server URL",
       "token": "Personal Access Token",
       "apiToken": "API Token",
-      "apiKey": "API Key"
+      "apiKey": "API Key",
+      "useCustomBaseUrl": "Use self-hosted / Enterprise instance",
+      "invalidBaseUrl": "Enter a valid URL (http:// or https://)"
     },
     "testConnection": "Test Connection",
     "connectionSuccess": "Connection successful",

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -84,7 +84,9 @@
       "baseUrl": "サーバーURL",
       "token": "Personal Access Token",
       "apiToken": "APIトークン",
-      "apiKey": "APIキー"
+      "apiKey": "APIキー",
+      "useCustomBaseUrl": "セルフホスト / Enterprise インスタンスを使用する",
+      "invalidBaseUrl": "有効なURL（http:// または https://）を入力してください"
     },
     "testConnection": "接続テスト",
     "connectionSuccess": "接続に成功しました",

--- a/src/services/issue-provider/factory.ts
+++ b/src/services/issue-provider/factory.ts
@@ -1,3 +1,4 @@
+/** Factory for creating provider adapters and resolving provider credentials. */
 import type { IssueProviderAdapter } from "@/lib/types";
 
 import { AsanaAdapter } from "./asana/asana";
@@ -10,16 +11,19 @@ import { RedmineAdapter } from "./redmine/redmine";
 import { getProviderMetadata } from "./registry";
 import { TrelloAdapter } from "./trello/trello";
 
+/** Credentials for a GitHub provider. */
 export interface GitHubCredentials {
   token: string;
 }
 
+/** Credentials for a Jira provider. */
 export interface JiraCredentials {
   baseUrl: string;
   email: string;
   apiToken: string;
 }
 
+/** Credentials for a Redmine provider. */
 export interface RedmineCredentials {
   baseUrl: string;
   apiKey: string;
@@ -52,6 +56,7 @@ export interface BacklogCredentials {
   apiKey: string;
 }
 
+/** Discriminated union of all provider credential types. */
 export type ProviderCredentials =
   | GitHubCredentials
   | JiraCredentials
@@ -75,9 +80,9 @@ export function getProviderIconUrl(type: string): string | null {
  * Creates an {@link IssueProviderAdapter} for the given provider type and credentials.
  * @param type - The provider type string (e.g. `"GITHUB"`).
  * @param credentials - Decrypted credentials for the provider.
- * @param baseUrl - Optional base URL for providers that use a separate base URL
- *   (e.g. GitLab self-hosted instances). Ignored by GitHub/Jira/Redmine whose
- *   `baseUrl` is already embedded in their credential types.
+ * @param baseUrl - Optional base URL for providers that support a separate base URL
+ *   (e.g. GitHub Enterprise Server, GitLab self-hosted instances).
+ *   Ignored by Jira/Redmine/Backlog whose `baseUrl` is embedded in their credential types.
  * @throws If the provider type is not supported.
  */
 export function createAdapter(

--- a/src/services/issue-provider/factory.ts
+++ b/src/services/issue-provider/factory.ts
@@ -88,7 +88,8 @@ export function createAdapter(
   switch (type) {
     case "GITHUB": {
       const creds = credentials as GitHubCredentials;
-      return new GitHubAdapter(creds.token);
+      const normalized = baseUrl?.trim();
+      return new GitHubAdapter(creds.token, normalized || undefined);
     }
     case "JIRA": {
       const creds = credentials as JiraCredentials;

--- a/src/services/issue-provider/github/github.metadata.ts
+++ b/src/services/issue-provider/github/github.metadata.ts
@@ -1,3 +1,4 @@
+/** GitHub provider metadata — credential schema, fields, and baseUrl mode. */
 import { z } from "zod";
 
 import type { ProviderMetadata } from "@/services/issue-provider/metadata";

--- a/src/services/issue-provider/github/github.metadata.ts
+++ b/src/services/issue-provider/github/github.metadata.ts
@@ -16,7 +16,7 @@ export const githubMetadata: ProviderMetadata = {
   type: "GITHUB",
   displayName: "GitHub",
   iconUrl: "/providers/github.svg",
-  baseUrlMode: "none",
+  baseUrlMode: "optional",
   credentialFields: [
     { key: "token", labelKey: "token", inputType: "password", required: true },
   ],

--- a/src/services/issue-provider/github/github.ts
+++ b/src/services/issue-provider/github/github.ts
@@ -1,3 +1,4 @@
+/** GitHub issue provider adapter — supports both github.com and GitHub Enterprise Server. */
 import axios from "axios";
 
 import { buildAxiosProxyConfig } from "@/lib/proxy/proxy";
@@ -59,12 +60,17 @@ export class GitHubAdapter implements IssueProviderAdapter {
 
   /**
    * Returns the authenticated GitHub username, cached after the first call.
+   * On rejection the cache is cleared so the next call can retry.
    */
   private getLogin(): Promise<string> {
     if (!this.loginPromise) {
       this.loginPromise = this.client
         .get<GitHubUser>("/user")
-        .then(({ data }) => data.login);
+        .then(({ data }) => data.login)
+        .catch((error: unknown) => {
+          this.loginPromise = null;
+          throw error;
+        });
     }
     return this.loginPromise;
   }
@@ -118,6 +124,7 @@ export class GitHubAdapter implements IssueProviderAdapter {
    * Normalizes a GitHub issue/PR to the common NormalizedIssue format.
    * @param issue - Raw GitHub issue/PR object.
    * @param isUnassigned - Whether the issue should be marked as unassigned.
+   * @returns Normalized issue compatible with the unified issue list.
    */
   private normalizeIssue(issue: GitHubIssue, isUnassigned: boolean): NormalizedIssue {
     return {
@@ -180,6 +187,9 @@ export class GitHubAdapter implements IssueProviderAdapter {
       });
       repos.push(...data);
       if (data.length < 100) { break; }
+      if (page >= MAX_PAGES) {
+        throw new Error(`listProjects: exceeded MAX_PAGES (${MAX_PAGES})`);
+      }
       page++;
     }
 
@@ -225,10 +235,13 @@ export class GitHubAdapter implements IssueProviderAdapter {
     while (true) {
       const { data } = await this.client.get<GitHubIssue[]>(
         `/repos/${owner}/${repo}/issues`,
-        { params: { state: "open", assignee: "none", per_page: 100, page } }
+        { params: { state: "open", assignee: "none", per_page: 100, page } },
       );
       issues.push(...data);
       if (data.length < 100) { break; }
+      if (page >= MAX_PAGES) {
+        throw new Error(`fetchUnassignedIssues: exceeded MAX_PAGES (${MAX_PAGES}) for ${owner}/${repo}`);
+      }
       page++;
     }
 
@@ -238,17 +251,23 @@ export class GitHubAdapter implements IssueProviderAdapter {
   /** {@inheritDoc} */
   async closeIssue(projectExternalId: string, issueExternalId: string): Promise<void> {
     const { owner, repo } = this.parseOwnerRepo(projectExternalId);
-    await this.client.patch(`/repos/${owner}/${repo}/issues/${issueExternalId}`, {
+    const { status } = await this.client.patch(`/repos/${owner}/${repo}/issues/${issueExternalId}`, {
       state: "closed",
     });
+    if (status < 200 || status >= 300) {
+      throw new Error(`closeIssue failed with status ${status}`);
+    }
   }
 
   /** {@inheritDoc} */
   async addComment(projectExternalId: string, issueExternalId: string, comment: string): Promise<void> {
     const { owner, repo } = this.parseOwnerRepo(projectExternalId);
-    await this.client.post(`/repos/${owner}/${repo}/issues/${issueExternalId}/comments`, {
+    const { status } = await this.client.post(`/repos/${owner}/${repo}/issues/${issueExternalId}/comments`, {
       body: comment,
     });
+    if (status < 200 || status >= 300) {
+      throw new Error(`addComment failed with status ${status}`);
+    }
   }
 }
 

--- a/src/services/issue-provider/github/github.ts
+++ b/src/services/issue-provider/github/github.ts
@@ -36,8 +36,16 @@ export class GitHubAdapter implements IssueProviderAdapter {
   private readonly client;
   private loginPromise: Promise<string> | null = null;
 
-  constructor(token: string) {
-    const BASE_URL = "https://api.github.com";
+  /**
+   * @param token - GitHub personal access token.
+   * @param baseUrl - Optional GHE base URL (e.g. `"https://github.example.com"`).
+   *   When provided, the REST API base becomes `${baseUrl}/api/v3`.
+   *   When omitted or null, defaults to `https://api.github.com`.
+   */
+  constructor(token: string, baseUrl?: string | null) {
+    const BASE_URL = baseUrl
+      ? `${baseUrl.replace(/\/$/, "")}/api/v3`
+      : "https://api.github.com";
     this.client = axios.create({
       baseURL: BASE_URL,
       headers: {

--- a/src/services/issue-provider/github/github.ts
+++ b/src/services/issue-provider/github/github.ts
@@ -38,6 +38,39 @@ export class GitHubAdapter implements IssueProviderAdapter {
   private loginPromise: Promise<string> | null = null;
 
   /**
+   * Generic paginator for GitHub REST/Search endpoints.
+   * Calls `url` with `{ ...params, per_page: 100, page }` on each iteration,
+   * extracts items via `extractItems`, and stops when a page returns fewer than 100 items.
+   * @param url - API path (relative to the axios base URL).
+   * @param params - Additional query parameters (merged with per_page / page).
+   * @param extractItems - Converts the raw response data to an array of T.
+   * @param label - Short label used in the MAX_PAGES error message.
+   * @throws If more than {@link MAX_PAGES} pages are required.
+   */
+  private async paginateGitHub<T>(
+    url: string,
+    params: Record<string, unknown>,
+    extractItems: (data: unknown) => T[],
+    label: string,
+  ): Promise<T[]> {
+    const items: T[] = [];
+    let page = 1;
+
+    while (true) {
+      const { data } = await this.client.get<unknown>(url, { params: { ...params, per_page: 100, page } });
+      const batch = extractItems(data);
+      items.push(...batch);
+      if (batch.length < 100) { break; }
+      if (page >= MAX_PAGES) {
+        throw new Error(`${label}: exceeded MAX_PAGES (${MAX_PAGES})`);
+      }
+      page++;
+    }
+
+    return items;
+  }
+
+  /**
    * @param token - GitHub personal access token.
    * @param baseUrl - Optional GHE base URL (e.g. `"https://github.example.com"`).
    *   When provided, the REST API base becomes `${baseUrl}/api/v3`.
@@ -100,24 +133,13 @@ export class GitHubAdapter implements IssueProviderAdapter {
    * @returns Flat array of issues across all pages.
    * @throws If more than {@link MAX_PAGES} pages are required or any request fails.
    */
-  private async fetchAssignedPages(owner: string, repo: string, login: string): Promise<GitHubIssue[]> {
-    const items: GitHubIssue[] = [];
-    let page = 1;
-
-    while (true) {
-      const { data } = await this.client.get<GitHubIssue[]>(
-        `/repos/${owner}/${repo}/issues`,
-        { params: { state: "open", assignee: login, per_page: 100, page } },
-      );
-      items.push(...data);
-      if (data.length < 100) { break; }
-      if (page >= MAX_PAGES) {
-        throw new Error(`fetchAssignedPages: exceeded MAX_PAGES (${MAX_PAGES}) for ${owner}/${repo}`);
-      }
-      page++;
-    }
-
-    return items;
+  private fetchAssignedPages(owner: string, repo: string, login: string): Promise<GitHubIssue[]> {
+    return this.paginateGitHub<GitHubIssue>(
+      `/repos/${owner}/${repo}/issues`,
+      { state: "open", assignee: login },
+      (data) => data as GitHubIssue[],
+      `fetchAssignedPages for ${owner}/${repo}`,
+    );
   }
 
   /**
@@ -148,27 +170,13 @@ export class GitHubAdapter implements IssueProviderAdapter {
    * @returns Array of PRs the user is requested to review.
    * @throws If more than {@link MAX_PAGES} pages are required or any request fails.
    */
-  private async fetchReviewerPrs(owner: string, repo: string, login: string): Promise<GitHubIssue[]> {
-    const prs: GitHubIssue[] = [];
-    let page = 1;
-
-    while (true) {
-      const { data } = await this.client.get<{ items: GitHubIssue[] }>("/search/issues", {
-        params: {
-          q: `is:pr is:open review-requested:${login} repo:${owner}/${repo}`,
-          per_page: 100,
-          page,
-        },
-      });
-      prs.push(...data.items);
-      if (data.items.length < 100) { break; }
-      if (page >= MAX_PAGES) {
-        throw new Error(`fetchReviewerPrs: exceeded MAX_PAGES (${MAX_PAGES}) for ${owner}/${repo}`);
-      }
-      page++;
-    }
-
-    return prs;
+  private fetchReviewerPrs(owner: string, repo: string, login: string): Promise<GitHubIssue[]> {
+    return this.paginateGitHub<GitHubIssue>(
+      "/search/issues",
+      { q: `is:pr is:open review-requested:${login} repo:${owner}/${repo}` },
+      (data) => (data as { items: GitHubIssue[] }).items,
+      `fetchReviewerPrs for ${owner}/${repo}`,
+    );
   }
 
   /** {@inheritDoc} */
@@ -178,21 +186,12 @@ export class GitHubAdapter implements IssueProviderAdapter {
 
   /** {@inheritDoc} */
   async listProjects(): Promise<ExternalProject[]> {
-    const repos: GitHubRepo[] = [];
-    let page = 1;
-
-    while (true) {
-      const { data } = await this.client.get<GitHubRepo[]>("/user/repos", {
-        params: { per_page: 100, page },
-      });
-      repos.push(...data);
-      if (data.length < 100) { break; }
-      if (page >= MAX_PAGES) {
-        throw new Error(`listProjects: exceeded MAX_PAGES (${MAX_PAGES})`);
-      }
-      page++;
-    }
-
+    const repos = await this.paginateGitHub<GitHubRepo>(
+      "/user/repos",
+      {},
+      (data) => data as GitHubRepo[],
+      "listProjects",
+    );
     return repos.map((r) => ({ externalId: r.full_name, displayName: r.full_name }));
   }
 
@@ -207,44 +206,25 @@ export class GitHubAdapter implements IssueProviderAdapter {
     ]);
 
     const seen = new Set<string>();
-    const results: NormalizedIssue[] = [];
-
-    for (const issue of issues) {
-      const id = String(issue.number);
-      if (seen.has(id)) { continue; }
-      seen.add(id);
-      results.push(this.normalizeIssue(issue, false));
-    }
-
-    for (const pr of reviewerPrs) {
-      const id = String(pr.number);
-      if (seen.has(id)) { continue; }
-      seen.add(id);
-      results.push(this.normalizeIssue(pr, false));
-    }
-
-    return results;
+    return [...issues, ...reviewerPrs]
+      .filter((item) => {
+        const id = String(item.number);
+        if (seen.has(id)) { return false; }
+        seen.add(id);
+        return true;
+      })
+      .map((item) => this.normalizeIssue(item, false));
   }
 
   /** {@inheritDoc} */
   async fetchUnassignedIssues(projectExternalId: string): Promise<NormalizedIssue[]> {
     const { owner, repo } = this.parseOwnerRepo(projectExternalId);
-    const issues: GitHubIssue[] = [];
-    let page = 1;
-
-    while (true) {
-      const { data } = await this.client.get<GitHubIssue[]>(
-        `/repos/${owner}/${repo}/issues`,
-        { params: { state: "open", assignee: "none", per_page: 100, page } },
-      );
-      issues.push(...data);
-      if (data.length < 100) { break; }
-      if (page >= MAX_PAGES) {
-        throw new Error(`fetchUnassignedIssues: exceeded MAX_PAGES (${MAX_PAGES}) for ${owner}/${repo}`);
-      }
-      page++;
-    }
-
+    const issues = await this.paginateGitHub<GitHubIssue>(
+      `/repos/${owner}/${repo}/issues`,
+      { state: "open", assignee: "none" },
+      (data) => data as GitHubIssue[],
+      `fetchUnassignedIssues for ${owner}/${repo}`,
+    );
     return issues.map((issue) => this.normalizeIssue(issue, true));
   }
 

--- a/tests/e2e/providers-ghe.spec.ts
+++ b/tests/e2e/providers-ghe.spec.ts
@@ -1,0 +1,259 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const E2E_EMAIL = process.env.E2E_USER_EMAIL ?? "admin@example.com";
+const E2E_PASSWORD = process.env.E2E_USER_PASSWORD ?? "password123";
+
+async function loginAndGoToProviders(page: Page): Promise<void> {
+  await page.goto("/login");
+  await page.fill('[name="email"]', E2E_EMAIL);
+  await page.fill('[name="password"]', E2E_PASSWORD);
+  await page.click('button[type="submit"]');
+  await page.waitForURL("/");
+  await page.goto("/settings/providers");
+}
+
+async function openAddProviderDialog(page: Page): Promise<void> {
+  await page.getByRole("button", { name: /add issue tracker/i }).click();
+  await expect(page.locator('[role="dialog"]')).toBeVisible();
+}
+
+async function selectGitHubProvider(page: Page): Promise<void> {
+  await page.getByLabel(/type/i).click();
+  await page.getByRole("option", { name: /github/i }).click();
+}
+
+// ---------------------------------------------------------------------------
+// US1: GitHub Enterprise registration
+// ---------------------------------------------------------------------------
+
+test.describe("US1 — GHE provider registration", () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAndGoToProviders(page);
+  });
+
+  test("GHE checkbox is visible when GitHub is selected", async ({ page }) => {
+    await openAddProviderDialog(page);
+    await selectGitHubProvider(page);
+    await expect(page.getByLabel(/self-hosted.*enterprise/i)).toBeVisible();
+  });
+
+  test("URL field is disabled when GHE checkbox is unchecked", async ({ page }) => {
+    await openAddProviderDialog(page);
+    await selectGitHubProvider(page);
+    const urlField = page.getByLabel(/server url/i).first();
+    await expect(urlField).toBeDisabled();
+  });
+
+  test("URL field becomes enabled when GHE checkbox is checked", async ({ page }) => {
+    await openAddProviderDialog(page);
+    await selectGitHubProvider(page);
+    await page.getByLabel(/self-hosted.*enterprise/i).click();
+    const urlField = page.getByLabel(/server url/i).first();
+    await expect(urlField).toBeEnabled();
+  });
+
+  test("registering GHE provider stores baseUrl (checkbox ON)", async ({ page }) => {
+    const createdProviders: unknown[] = [];
+
+    await page.route("**/api/providers", (route) => {
+      if (route.request().method() === "POST") {
+        const body = JSON.parse(route.request().postData() ?? "{}") as {
+          credentials?: { baseUrl?: string };
+        };
+        createdProviders.push(body);
+        void route.fulfill({
+          status: 201,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: true,
+            data: {
+              id: "ghe-provider-id",
+              type: "GITHUB",
+              displayName: "Acme GHE",
+              baseUrl: body.credentials?.baseUrl ?? null,
+              createdAt: new Date().toISOString(),
+              iconUrl: "/providers/github.svg",
+            },
+          }),
+        });
+      } else {
+        void route.continue();
+      }
+    });
+
+    await openAddProviderDialog(page);
+    await selectGitHubProvider(page);
+    await page.fill('[data-testid="provider-name-input"]', "Acme GHE");
+    await page.getByLabel(/self-hosted.*enterprise/i).click();
+    await page.getByLabel(/server url/i).first().fill("https://github.example.com");
+    await page.fill('[data-testid="token-input"]', "ghp_enterprise_token");
+    await page.getByRole("button", { name: /add issue tracker/i }).click();
+
+    await expect(page.locator('[role="dialog"]')).not.toBeVisible();
+    expect(createdProviders).toHaveLength(1);
+    const posted = createdProviders[0] as { credentials?: { baseUrl?: string } };
+    expect(posted.credentials?.baseUrl).toBe("https://github.example.com");
+  });
+
+  test("registering github.com provider stores null baseUrl (checkbox OFF)", async ({ page }) => {
+    const createdProviders: unknown[] = [];
+
+    await page.route("**/api/providers", (route) => {
+      if (route.request().method() === "POST") {
+        const body = JSON.parse(route.request().postData() ?? "{}") as object;
+        createdProviders.push(body);
+        void route.fulfill({
+          status: 201,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: true,
+            data: {
+              id: "gh-provider-id",
+              type: "GITHUB",
+              displayName: "My GitHub",
+              baseUrl: null,
+              createdAt: new Date().toISOString(),
+              iconUrl: "/providers/github.svg",
+            },
+          }),
+        });
+      } else {
+        void route.continue();
+      }
+    });
+
+    await openAddProviderDialog(page);
+    await selectGitHubProvider(page);
+    await page.fill('[data-testid="provider-name-input"]', "My GitHub");
+    await page.fill('[data-testid="token-input"]', "ghp_token");
+    await page.getByRole("button", { name: /add issue tracker/i }).click();
+
+    await expect(page.locator('[role="dialog"]')).not.toBeVisible();
+    expect(createdProviders).toHaveLength(1);
+    const posted = createdProviders[0] as { credentials?: { baseUrl?: string } };
+    expect(posted.credentials?.baseUrl).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// US2: URL format validation
+// ---------------------------------------------------------------------------
+
+test.describe("US2 — GHE URL format validation", () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAndGoToProviders(page);
+  });
+
+  test("shows inline error for invalid URL (no scheme)", async ({ page }) => {
+    await openAddProviderDialog(page);
+    await selectGitHubProvider(page);
+    await page.getByLabel(/self-hosted.*enterprise/i).click();
+    await page.getByLabel(/server url/i).first().fill("notaurl");
+    await page.getByLabel(/server url/i).first().blur();
+    await expect(page.getByText(/valid url/i)).toBeVisible();
+  });
+
+  test("shows inline error for ftp:// scheme", async ({ page }) => {
+    await openAddProviderDialog(page);
+    await selectGitHubProvider(page);
+    await page.getByLabel(/self-hosted.*enterprise/i).click();
+    await page.getByLabel(/server url/i).first().fill("ftp://example.com");
+    await page.getByLabel(/server url/i).first().blur();
+    await expect(page.getByText(/valid url/i)).toBeVisible();
+  });
+
+  test("error clears when a valid URL is entered", async ({ page }) => {
+    await openAddProviderDialog(page);
+    await selectGitHubProvider(page);
+    await page.getByLabel(/self-hosted.*enterprise/i).click();
+    const urlField = page.getByLabel(/server url/i).first();
+    await urlField.fill("notaurl");
+    await urlField.blur();
+    await expect(page.getByText(/valid url/i)).toBeVisible();
+    await urlField.fill("https://github.example.com");
+    await urlField.blur();
+    await expect(page.getByText(/valid url/i)).not.toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// US3: Edit GHE provider
+// ---------------------------------------------------------------------------
+
+test.describe("US3 — GHE provider edit and toggle", () => {
+  const GHE_PROVIDER = {
+    id: "p-ghe",
+    type: "GITHUB",
+    displayName: "Acme GHE",
+    baseUrl: "https://github.example.com",
+    iconUrl: "/providers/github.svg",
+  };
+
+  test.beforeEach(async ({ page }) => {
+    await loginAndGoToProviders(page);
+  });
+
+  test("edit modal shows checkbox ON and saved URL for GHE provider", async ({ page }) => {
+    await page.route("**/api/providers", (route) => {
+      if (route.request().method() === "GET") {
+        void route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ success: true, data: [GHE_PROVIDER] }),
+        });
+      } else {
+        void route.continue();
+      }
+    });
+
+    await page.reload();
+    await page.getByRole("button", { name: /edit/i }).first().click();
+    await expect(page.locator('[role="dialog"]')).toBeVisible();
+    await expect(page.getByLabel(/self-hosted.*enterprise/i)).toBeChecked();
+    await expect(page.getByLabel(/server url/i).first()).toHaveValue("https://github.example.com");
+  });
+
+  test("toggling GHE OFF sends empty baseUrl to PATCH (→ null)", async ({ page }) => {
+    const patchBodies: unknown[] = [];
+
+    await page.route("**/api/providers", (route) => {
+      if (route.request().method() === "GET") {
+        void route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ success: true, data: [GHE_PROVIDER] }),
+        });
+      } else {
+        void route.continue();
+      }
+    });
+
+    await page.route(`**/api/providers/${GHE_PROVIDER.id}`, (route) => {
+      if (route.request().method() === "PATCH") {
+        const body = JSON.parse(route.request().postData() ?? "{}") as object;
+        patchBodies.push(body);
+        void route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: true,
+            data: { ...GHE_PROVIDER, baseUrl: null },
+          }),
+        });
+      } else {
+        void route.continue();
+      }
+    });
+
+    await page.reload();
+    await page.getByRole("button", { name: /edit/i }).first().click();
+    await expect(page.locator('[role="dialog"]')).toBeVisible();
+    await page.getByLabel(/self-hosted.*enterprise/i).click(); // toggle OFF
+    await page.getByRole("button", { name: /update/i }).click();
+
+    await expect(page.locator('[role="dialog"]')).not.toBeVisible();
+    expect(patchBodies).toHaveLength(1);
+    const patched = patchBodies[0] as { baseUrl?: string };
+    expect(patched.baseUrl).toBe("");
+  });
+});

--- a/tests/unit/api/providers.test.ts
+++ b/tests/unit/api/providers.test.ts
@@ -897,6 +897,56 @@ describe("POST /api/providers — INVALID_BASE_URL (T014)", () => {
     expect(json.error).toBe("INVALID_BASE_URL");
   });
 
+  it("returns 400 INVALID_BODY when credentials is a string (not an object)", async () => {
+    const req = makeRequest("POST", {
+      type: "GITHUB",
+      displayName: "My GitHub",
+      credentials: "not-an-object",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("INVALID_BODY");
+  });
+
+  it("returns 400 INVALID_BODY when credentials is an array", async () => {
+    const req = makeRequest("POST", {
+      type: "GITHUB",
+      displayName: "My GitHub",
+      credentials: ["token", "value"],
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("INVALID_BODY");
+  });
+
+  it("trims whitespace from baseUrl before validation and saves trimmed value", async () => {
+    const { GitHubAdapter } = jest.requireMock("@/services/issue-provider/github/github");
+    GitHubAdapter.mockClear();
+    GitHubAdapter.mockImplementationOnce(() => ({
+      testConnection: jest.fn().mockResolvedValue(undefined),
+    }));
+    mockCreate.mockResolvedValue({
+      id: "p-ghe",
+      type: "GITHUB",
+      displayName: "Acme GHE",
+      baseUrl: "https://github.example.com",
+      createdAt: new Date(),
+    });
+
+    const req = makeRequest("POST", {
+      type: "GITHUB",
+      displayName: "Acme GHE",
+      credentials: { token: "ghp_xxx", baseUrl: "  https://github.example.com  " },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+
+    const createCall = mockCreate.mock.calls[0][0];
+    expect(createCall.data.baseUrl).toBe("https://github.example.com");
+  });
+
   it("allows POST GITHUB without baseUrl (github.com path) — no INVALID_BASE_URL", async () => {
     const { GitHubAdapter } = jest.requireMock("@/services/issue-provider/github/github");
     GitHubAdapter.mockImplementationOnce(() => ({
@@ -1040,6 +1090,44 @@ describe("PATCH /api/providers/[id] — US3 baseUrl transitions (T019)", () => {
     expect(res.status).toBe(200);
     const updateCall = mockUpdate.mock.calls[0][0];
     expect(updateCall.data.baseUrl).toBe("https://new.example.com");
+  });
+
+  it("returns 400 INVALID_BODY when PATCH sends baseUrl for baseUrlMode=none provider (LINEAR)", async () => {
+    mockFindFirst.mockResolvedValue({ id: "p1", userId: "user-1", type: "LINEAR", encryptedCredentials: "enc", baseUrl: null });
+
+    const req = makeRequest("PATCH", {
+      displayName: "My Linear",
+      baseUrl: "https://linear.example.com",
+      changeCredentials: false,
+    }, "http://localhost/api/providers/p1");
+    const res = await PATCH(req, { params: Promise.resolve({ id: "p1" }) });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("INVALID_BODY");
+  });
+
+  it("trims whitespace from PATCH baseUrl before validation and saves trimmed value", async () => {
+    const { GitHubAdapter } = jest.requireMock("@/services/issue-provider/github/github");
+    GitHubAdapter.mockClear();
+    GitHubAdapter.mockImplementationOnce(() => ({
+      testConnection: jest.fn().mockResolvedValue(undefined),
+    }));
+
+    mockFindFirst.mockResolvedValue({ id: "p1", userId: "user-1", type: "GITHUB", encryptedCredentials: "enc", baseUrl: null });
+    mockDecrypt.mockReturnValue(JSON.stringify({ token: "ghp_token" }));
+    mockUpdate.mockResolvedValue({ id: "p1", type: "GITHUB", displayName: "My GHE", baseUrl: "https://github.example.com", createdAt: new Date() });
+
+    const req = makeRequest("PATCH", {
+      displayName: "My GHE",
+      baseUrl: "  https://github.example.com  ",
+      changeCredentials: false,
+    }, "http://localhost/api/providers/p1");
+    const res = await PATCH(req, { params: Promise.resolve({ id: "p1" }) });
+
+    expect(res.status).toBe(200);
+    const updateCall = mockUpdate.mock.calls[0][0];
+    expect(updateCall.data.baseUrl).toBe("https://github.example.com");
   });
 
   it("leaves baseUrl unchanged when not sent (existing github.com provider unaffected)", async () => {

--- a/tests/unit/api/providers.test.ts
+++ b/tests/unit/api/providers.test.ts
@@ -1,4 +1,7 @@
-/** @jest-environment node */
+/**
+ * Unit tests for the provider API routes (GET, POST, PATCH, DELETE).
+ * @jest-environment node
+ */
 import { GET, POST } from "@/app/api/providers/route";
 import { DELETE, PATCH } from "@/app/api/providers/[id]/route";
 import { NextRequest } from "next/server";
@@ -177,6 +180,17 @@ describe("GET /api/providers", () => {
       })
     );
   });
+
+  it("returns 500 when Prisma findMany fails", async () => {
+    mockFindMany.mockRejectedValueOnce(new Error("Database connection lost"));
+
+    const req = makeRequest("GET");
+    const res = await GET(req);
+
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe("INTERNAL_ERROR");
+  });
 });
 
 describe("POST /api/providers", () => {
@@ -322,6 +336,18 @@ describe("DELETE /api/providers/[id]", () => {
     const res = await DELETE(req, { params: Promise.resolve({ id: "p1" }) });
 
     expect(res.status).toBe(401);
+  });
+
+  it("returns 500 when Prisma delete fails", async () => {
+    mockFindFirst.mockResolvedValue({ id: "p1", userId: "user-1" });
+    mockDelete.mockRejectedValueOnce(new Error("Foreign key constraint violation"));
+
+    const req = makeRequest("DELETE", undefined, "http://localhost/api/providers/p1");
+    const res = await DELETE(req, { params: Promise.resolve({ id: "p1" }) });
+
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe("INTERNAL_ERROR");
   });
 });
 
@@ -502,6 +528,28 @@ describe("PATCH /api/providers/[id]", () => {
     const res = await PATCH(req, { params: Promise.resolve({ id: "p1" }) });
 
     expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when changeCredentials is not a boolean (Zod validation)", async () => {
+    mockFindFirst.mockResolvedValue({ id: "p1", userId: "user-1", type: "GITHUB", encryptedCredentials: "enc", baseUrl: null });
+
+    const req = makeRequest("PATCH", { displayName: "X", changeCredentials: "true" }, "http://localhost/api/providers/p1");
+    const res = await PATCH(req, { params: Promise.resolve({ id: "p1" }) });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("INVALID_BODY");
+  });
+
+  it("returns 400 when displayName is missing from body (Zod validation)", async () => {
+    mockFindFirst.mockResolvedValue({ id: "p1", userId: "user-1", type: "GITHUB", encryptedCredentials: "enc", baseUrl: null });
+
+    const req = makeRequest("PATCH", { changeCredentials: false, baseUrl: "https://example.com" }, "http://localhost/api/providers/p1");
+    const res = await PATCH(req, { params: Promise.resolve({ id: "p1" }) });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("INVALID_BODY");
   });
 
   it("returns 403 when provider belongs to different user", async () => {

--- a/tests/unit/api/providers.test.ts
+++ b/tests/unit/api/providers.test.ts
@@ -72,7 +72,7 @@ jest.mock("@/services/issue-provider/asana/asana", () => ({
 // Mock registry — getProviderMetadata returns iconUrl, baseUrlMode, and credentialFields
 type MockMeta = { type: string; iconUrl: string; baseUrlMode: string; credentialFields: { key: string; required: boolean }[]; credentialSchema: { parse: (x: unknown) => unknown } };
 const MOCK_REGISTRY: Record<string, MockMeta> = {
-  GITHUB: { type: "GITHUB", iconUrl: "/providers/github.svg", baseUrlMode: "none", credentialFields: [{ key: "token", required: true }], credentialSchema: { parse: (x) => x } },
+  GITHUB: { type: "GITHUB", iconUrl: "/providers/github.svg", baseUrlMode: "optional", credentialFields: [{ key: "token", required: true }], credentialSchema: { parse: (x) => x } },
   JIRA: { type: "JIRA", iconUrl: "/providers/jira.svg", baseUrlMode: "required", credentialFields: [{ key: "email", required: true }, { key: "apiToken", required: true }], credentialSchema: { parse: (x) => x } },
   REDMINE: { type: "REDMINE", iconUrl: "/providers/redmine.svg", baseUrlMode: "required", credentialFields: [{ key: "apiKey", required: true }], credentialSchema: { parse: (x) => x } },
   GITLAB: { type: "GITLAB", iconUrl: "/providers/gitlab.svg", baseUrlMode: "optional", credentialFields: [{ key: "token", required: true }], credentialSchema: { parse: (x) => x } },
@@ -425,6 +425,66 @@ describe("POST /api/providers — baseUrl separation", () => {
     const createCall = mockCreate.mock.calls[0][0];
     expect(createCall.data.baseUrl).toBeUndefined();
   });
+
+  // T008 — US1: POST stores GitHub Enterprise baseUrl and passes it to the adapter
+  it("stores GHE baseUrl in DB and passes it to GitHubAdapter (T008)", async () => {
+    const { GitHubAdapter } = jest.requireMock("@/services/issue-provider/github/github");
+    GitHubAdapter.mockClear();
+    GitHubAdapter.mockImplementationOnce(() => ({
+      testConnection: jest.fn().mockResolvedValue(undefined),
+    }));
+
+    mockCreate.mockResolvedValue({
+      id: "p-ghe",
+      type: "GITHUB",
+      displayName: "Acme GHE",
+      baseUrl: "https://github.example.com",
+      createdAt: new Date(),
+    });
+
+    const req = makeRequest("POST", {
+      type: "GITHUB",
+      displayName: "Acme GHE",
+      credentials: { token: "ghp_xxx", baseUrl: "https://github.example.com" },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+
+    // baseUrl must be stored in the DB field
+    const createCall = mockCreate.mock.calls[0][0];
+    expect(createCall.data.baseUrl).toBe("https://github.example.com");
+
+    // GitHubAdapter must receive both token AND baseUrl
+    expect(GitHubAdapter).toHaveBeenCalledWith("ghp_xxx", "https://github.example.com");
+  });
+
+  // T008 — US1: POST without baseUrl (github.com) stores null
+  it("stores null baseUrl when no baseUrl in credentials (github.com path, T008)", async () => {
+    const { GitHubAdapter } = jest.requireMock("@/services/issue-provider/github/github");
+    GitHubAdapter.mockClear();
+    GitHubAdapter.mockImplementationOnce(() => ({
+      testConnection: jest.fn().mockResolvedValue(undefined),
+    }));
+
+    mockCreate.mockResolvedValue({
+      id: "p-gh",
+      type: "GITHUB",
+      displayName: "My GitHub",
+      baseUrl: null,
+      createdAt: new Date(),
+    });
+
+    const req = makeRequest("POST", {
+      type: "GITHUB",
+      displayName: "My GitHub",
+      credentials: { token: "ghp_test" },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+
+    // GitHubAdapter must receive token only (no baseUrl arg / null)
+    expect(GitHubAdapter).toHaveBeenCalledWith("ghp_test", undefined);
+  });
 });
 
 // --- T008: PATCH /api/providers/[id] tests ---
@@ -742,5 +802,217 @@ describe("PATCH /api/providers/[id] — baseUrlMode validation", () => {
     const res = await PATCH(req, { params: Promise.resolve({ id: "p1" }) });
 
     expect(res.status).toBe(200);
+  });
+});
+
+// T014 — US2: INVALID_BASE_URL validation on POST and PATCH
+
+describe("POST /api/providers — INVALID_BASE_URL (T014)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuth.mockResolvedValue(SESSION);
+  });
+
+  it("returns 400 INVALID_BASE_URL for POST GITHUB with ftp:// baseUrl", async () => {
+    const req = makeRequest("POST", {
+      type: "GITHUB",
+      displayName: "Bad GHE",
+      credentials: { token: "ghp_xxx", baseUrl: "ftp://github.example.com" },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("INVALID_BASE_URL");
+  });
+
+  it("returns 400 INVALID_BASE_URL for POST GITHUB with plain-text baseUrl", async () => {
+    const req = makeRequest("POST", {
+      type: "GITHUB",
+      displayName: "Bad GHE",
+      credentials: { token: "ghp_xxx", baseUrl: "notaurl" },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("INVALID_BASE_URL");
+  });
+
+  it("returns 400 INVALID_BASE_URL for POST GITLAB with invalid baseUrl", async () => {
+    const req = makeRequest("POST", {
+      type: "GITLAB",
+      displayName: "Bad GitLab",
+      credentials: { token: "glpat-xxx", baseUrl: "notaurl" },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("INVALID_BASE_URL");
+  });
+
+  it("allows POST GITHUB without baseUrl (github.com path) — no INVALID_BASE_URL", async () => {
+    const { GitHubAdapter } = jest.requireMock("@/services/issue-provider/github/github");
+    GitHubAdapter.mockImplementationOnce(() => ({
+      testConnection: jest.fn().mockResolvedValue(undefined),
+    }));
+    mockCreate.mockResolvedValue({ id: "p1", type: "GITHUB", displayName: "My GitHub", baseUrl: null, createdAt: new Date() });
+
+    const req = makeRequest("POST", {
+      type: "GITHUB",
+      displayName: "My GitHub",
+      credentials: { token: "ghp_test" },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+  });
+});
+
+describe("PATCH /api/providers/[id] — INVALID_BASE_URL (T014)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuth.mockResolvedValue(SESSION);
+  });
+
+  it("returns 400 INVALID_BASE_URL for PATCH GITHUB with ftp:// baseUrl", async () => {
+    mockFindFirst.mockResolvedValue({ id: "p1", userId: "user-1", type: "GITHUB", encryptedCredentials: "enc", baseUrl: null });
+    mockDecrypt.mockReturnValue(JSON.stringify({ token: "ghp_token" }));
+
+    const req = makeRequest("PATCH", {
+      displayName: "My GHE",
+      baseUrl: "ftp://github.example.com",
+      changeCredentials: false,
+    }, "http://localhost/api/providers/p1");
+    const res = await PATCH(req, { params: Promise.resolve({ id: "p1" }) });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("INVALID_BASE_URL");
+  });
+
+  it("returns 400 INVALID_BASE_URL for PATCH GITHUB with plain-text baseUrl", async () => {
+    mockFindFirst.mockResolvedValue({ id: "p1", userId: "user-1", type: "GITHUB", encryptedCredentials: "enc", baseUrl: null });
+    mockDecrypt.mockReturnValue(JSON.stringify({ token: "ghp_token" }));
+
+    const req = makeRequest("PATCH", {
+      displayName: "My GHE",
+      baseUrl: "notaurl",
+      changeCredentials: false,
+    }, "http://localhost/api/providers/p1");
+    const res = await PATCH(req, { params: Promise.resolve({ id: "p1" }) });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("INVALID_BASE_URL");
+  });
+
+  it("returns 400 INVALID_BASE_URL for PATCH GITLAB with invalid baseUrl", async () => {
+    mockFindFirst.mockResolvedValue({ id: "p1", userId: "user-1", type: "GITLAB", encryptedCredentials: "enc", baseUrl: null });
+    mockDecrypt.mockReturnValue(JSON.stringify({ token: "glpat-token" }));
+
+    const req = makeRequest("PATCH", {
+      displayName: "My GitLab",
+      baseUrl: "javascript:alert(1)",
+      changeCredentials: false,
+    }, "http://localhost/api/providers/p1");
+    const res = await PATCH(req, { params: Promise.resolve({ id: "p1" }) });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("INVALID_BASE_URL");
+  });
+
+  it("allows PATCH with valid https baseUrl — no INVALID_BASE_URL", async () => {
+    const { GitHubAdapter } = jest.requireMock("@/services/issue-provider/github/github");
+    GitHubAdapter.mockImplementationOnce(() => ({
+      testConnection: jest.fn().mockResolvedValue(undefined),
+    }));
+
+    mockFindFirst.mockResolvedValue({ id: "p1", userId: "user-1", type: "GITHUB", encryptedCredentials: "enc", baseUrl: null });
+    mockDecrypt.mockReturnValue(JSON.stringify({ token: "ghp_token" }));
+    mockUpdate.mockResolvedValue({ id: "p1", type: "GITHUB", displayName: "My GHE", baseUrl: "https://github.example.com", createdAt: new Date() });
+
+    const req = makeRequest("PATCH", {
+      displayName: "My GHE",
+      baseUrl: "https://github.example.com",
+      changeCredentials: false,
+    }, "http://localhost/api/providers/p1");
+    const res = await PATCH(req, { params: Promise.resolve({ id: "p1" }) });
+
+    expect(res.status).toBe(200);
+  });
+});
+
+// T019 — US3: PATCH baseUrl state transitions
+
+describe("PATCH /api/providers/[id] — US3 baseUrl transitions (T019)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuth.mockResolvedValue(SESSION);
+  });
+
+  it("converts baseUrl='' to null (GHE OFF → github.com)", async () => {
+    const { GitHubAdapter } = jest.requireMock("@/services/issue-provider/github/github");
+    GitHubAdapter.mockImplementationOnce(() => ({
+      testConnection: jest.fn().mockResolvedValue(undefined),
+    }));
+
+    mockFindFirst.mockResolvedValue({ id: "p1", userId: "user-1", type: "GITHUB", encryptedCredentials: "enc", baseUrl: "https://github.example.com" });
+    mockDecrypt.mockReturnValue(JSON.stringify({ token: "ghp_token" }));
+    mockUpdate.mockResolvedValue({ id: "p1", type: "GITHUB", displayName: "My GHE", baseUrl: null, createdAt: new Date() });
+
+    const req = makeRequest("PATCH", {
+      displayName: "My GHE",
+      baseUrl: "",
+      changeCredentials: false,
+    }, "http://localhost/api/providers/p1");
+    const res = await PATCH(req, { params: Promise.resolve({ id: "p1" }) });
+
+    expect(res.status).toBe(200);
+    // DB update must set baseUrl to null (empty string = switch to github.com)
+    const updateCall = mockUpdate.mock.calls[0][0];
+    expect(updateCall.data.baseUrl).toBeNull();
+  });
+
+  it("changes GHE URL to a new valid URL", async () => {
+    const { GitHubAdapter } = jest.requireMock("@/services/issue-provider/github/github");
+    GitHubAdapter.mockImplementationOnce(() => ({
+      testConnection: jest.fn().mockResolvedValue(undefined),
+    }));
+
+    mockFindFirst.mockResolvedValue({ id: "p1", userId: "user-1", type: "GITHUB", encryptedCredentials: "enc", baseUrl: "https://old.example.com" });
+    mockDecrypt.mockReturnValue(JSON.stringify({ token: "ghp_token" }));
+    mockUpdate.mockResolvedValue({ id: "p1", type: "GITHUB", displayName: "My GHE", baseUrl: "https://new.example.com", createdAt: new Date() });
+
+    const req = makeRequest("PATCH", {
+      displayName: "My GHE",
+      baseUrl: "https://new.example.com",
+      changeCredentials: false,
+    }, "http://localhost/api/providers/p1");
+    const res = await PATCH(req, { params: Promise.resolve({ id: "p1" }) });
+
+    expect(res.status).toBe(200);
+    const updateCall = mockUpdate.mock.calls[0][0];
+    expect(updateCall.data.baseUrl).toBe("https://new.example.com");
+  });
+
+  it("leaves baseUrl unchanged when not sent (existing github.com provider unaffected)", async () => {
+    const { GitHubAdapter } = jest.requireMock("@/services/issue-provider/github/github");
+    GitHubAdapter.mockImplementationOnce(() => ({
+      testConnection: jest.fn().mockResolvedValue(undefined),
+    }));
+
+    mockFindFirst.mockResolvedValue({ id: "p1", userId: "user-1", type: "GITHUB", encryptedCredentials: "enc", baseUrl: null });
+    mockDecrypt.mockReturnValue(JSON.stringify({ token: "ghp_token" }));
+    mockUpdate.mockResolvedValue({ id: "p1", type: "GITHUB", displayName: "My GitHub", baseUrl: null, createdAt: new Date() });
+
+    const req = makeRequest("PATCH", {
+      displayName: "My GitHub",
+      changeCredentials: false,
+    }, "http://localhost/api/providers/p1");
+    const res = await PATCH(req, { params: Promise.resolve({ id: "p1" }) });
+
+    expect(res.status).toBe(200);
+    const updateCall = mockUpdate.mock.calls[0][0];
+    // No baseUrl key in update data means it's not being changed
+    expect(updateCall.data).not.toHaveProperty("baseUrl");
   });
 });

--- a/tests/unit/components/ProviderEditModal.test.ts
+++ b/tests/unit/components/ProviderEditModal.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit tests for ProviderEditModal utilities — buildPatchBody.
+ * @jest-environment node
+ */
+
+import { buildPatchBody } from "@/components/providers/ProviderEditModal";
+
+describe("buildPatchBody", () => {
+  const baseArgs = {
+    displayName: "My Provider",
+    changeCredentials: false,
+    credentials: {},
+    isRequired: false,
+    isOptional: false,
+    useCustomBaseUrl: false,
+    baseUrl: "",
+  };
+
+  it("includes displayName and changeCredentials always", () => {
+    const body = buildPatchBody(baseArgs);
+    expect(body.displayName).toBe("My Provider");
+    expect(body.changeCredentials).toBe(false);
+  });
+
+  it("does not include baseUrl when mode is neither required nor optional", () => {
+    const body = buildPatchBody(baseArgs);
+    expect(body).not.toHaveProperty("baseUrl");
+  });
+
+  it("includes baseUrl when isRequired is true", () => {
+    const body = buildPatchBody({ ...baseArgs, isRequired: true, baseUrl: "https://jira.example.com" });
+    expect(body.baseUrl).toBe("https://jira.example.com");
+  });
+
+  it("includes baseUrl when isOptional and useCustomBaseUrl are both true", () => {
+    const body = buildPatchBody({
+      ...baseArgs,
+      isOptional: true,
+      useCustomBaseUrl: true,
+      baseUrl: "https://github.example.com",
+    });
+    expect(body.baseUrl).toBe("https://github.example.com");
+  });
+
+  it("sets baseUrl to empty string when isOptional but useCustomBaseUrl is false (clear URL)", () => {
+    const body = buildPatchBody({
+      ...baseArgs,
+      isOptional: true,
+      useCustomBaseUrl: false,
+      baseUrl: "https://github.example.com",
+    });
+    expect(body.baseUrl).toBe("");
+  });
+
+  it("includes credentials when changeCredentials is true", () => {
+    const body = buildPatchBody({
+      ...baseArgs,
+      changeCredentials: true,
+      credentials: { token: "ghp_abc" },
+    });
+    expect(body.credentials).toEqual({ token: "ghp_abc" });
+  });
+
+  it("does not include credentials when changeCredentials is false", () => {
+    const body = buildPatchBody({ ...baseArgs, changeCredentials: false, credentials: { token: "ghp_abc" } });
+    expect(body).not.toHaveProperty("credentials");
+  });
+});

--- a/tests/unit/lib/validation/base-url.test.ts
+++ b/tests/unit/lib/validation/base-url.test.ts
@@ -1,0 +1,109 @@
+/** @jest-environment node */
+import { isValidBaseUrl } from "@/lib/validation/base-url";
+
+describe("isValidBaseUrl", () => {
+  describe("valid URLs", () => {
+    it("accepts https URL with hostname", () => {
+      expect(isValidBaseUrl("https://github.example.com")).toBe(true);
+    });
+
+    it("accepts http URL with hostname", () => {
+      expect(isValidBaseUrl("http://github.example.com")).toBe(true);
+    });
+
+    it("accepts https URL with trailing slash", () => {
+      expect(isValidBaseUrl("https://github.example.com/")).toBe(true);
+    });
+
+    it("accepts https URL with port", () => {
+      expect(isValidBaseUrl("https://github.example.com:8080")).toBe(true);
+    });
+
+    it("accepts https URL with path", () => {
+      expect(isValidBaseUrl("https://github.example.com/ghe")).toBe(true);
+    });
+  });
+
+  describe("invalid URLs", () => {
+    it("rejects empty string", () => {
+      expect(isValidBaseUrl("")).toBe(false);
+    });
+
+    it("rejects plain hostname with no scheme", () => {
+      expect(isValidBaseUrl("github.example.com")).toBe(false);
+    });
+
+    it("rejects ftp scheme", () => {
+      expect(isValidBaseUrl("ftp://github.example.com")).toBe(false);
+    });
+
+    it("rejects arbitrary text", () => {
+      expect(isValidBaseUrl("notaurl")).toBe(false);
+    });
+
+    it("rejects URL with no host", () => {
+      expect(isValidBaseUrl("https://")).toBe(false);
+    });
+
+    it("rejects javascript scheme", () => {
+      expect(isValidBaseUrl("javascript:alert(1)")).toBe(false);
+    });
+  });
+
+  describe("SSRF mitigations — private/loopback addresses", () => {
+    it("rejects localhost", () => {
+      expect(isValidBaseUrl("http://localhost")).toBe(false);
+    });
+
+    it("rejects 127.0.0.1 (IPv4 loopback)", () => {
+      expect(isValidBaseUrl("http://127.0.0.1")).toBe(false);
+    });
+
+    it("rejects 127.x.x.x range", () => {
+      expect(isValidBaseUrl("http://127.99.1.2")).toBe(false);
+    });
+
+    it("rejects 169.254.x.x (APIPA / link-local)", () => {
+      expect(isValidBaseUrl("http://169.254.169.254")).toBe(false);
+    });
+
+    it("rejects 10.x.x.x (RFC1918 class A)", () => {
+      expect(isValidBaseUrl("http://10.0.0.1")).toBe(false);
+    });
+
+    it("rejects 192.168.x.x (RFC1918 class C)", () => {
+      expect(isValidBaseUrl("http://192.168.1.1")).toBe(false);
+    });
+
+    it("rejects 172.16-31.x.x (RFC1918 class B)", () => {
+      expect(isValidBaseUrl("http://172.16.0.1")).toBe(false);
+      expect(isValidBaseUrl("http://172.31.255.255")).toBe(false);
+    });
+
+    it("rejects 0.0.0.0", () => {
+      expect(isValidBaseUrl("http://0.0.0.0")).toBe(false);
+    });
+
+    it("rejects IPv6 loopback ::1", () => {
+      expect(isValidBaseUrl("http://[::1]")).toBe(false);
+    });
+
+    it("rejects IPv6 link-local fe80::", () => {
+      expect(isValidBaseUrl("http://[fe80::1]")).toBe(false);
+    });
+
+    it("rejects IPv6 unique-local fc00::", () => {
+      expect(isValidBaseUrl("http://[fc00::1]")).toBe(false);
+    });
+  });
+
+  describe("SSRF mitigations — embedded credentials", () => {
+    it("rejects URL with username", () => {
+      expect(isValidBaseUrl("https://user@github.example.com")).toBe(false);
+    });
+
+    it("rejects URL with username and password", () => {
+      expect(isValidBaseUrl("https://user:pass@github.example.com")).toBe(false);
+    });
+  });
+});

--- a/tests/unit/lib/validation/base-url.test.ts
+++ b/tests/unit/lib/validation/base-url.test.ts
@@ -1,5 +1,5 @@
 /** @jest-environment node */
-import { isValidBaseUrl } from "@/lib/validation/base-url";
+import { getBaseUrlValidationError, isValidBaseUrl } from "@/lib/validation/base-url";
 
 describe("isValidBaseUrl", () => {
   describe("valid URLs", () => {
@@ -105,5 +105,27 @@ describe("isValidBaseUrl", () => {
     it("rejects URL with username and password", () => {
       expect(isValidBaseUrl("https://user:pass@github.example.com")).toBe(false);
     });
+  });
+});
+
+describe("getBaseUrlValidationError", () => {
+  it("returns null when enabled=false", () => {
+    expect(getBaseUrlValidationError(false, true, "bad", "Error msg")).toBeNull();
+  });
+
+  it("returns null when touched=false", () => {
+    expect(getBaseUrlValidationError(true, false, "bad", "Error msg")).toBeNull();
+  });
+
+  it("returns null when value is empty", () => {
+    expect(getBaseUrlValidationError(true, true, "", "Error msg")).toBeNull();
+  });
+
+  it("returns null when value is valid", () => {
+    expect(getBaseUrlValidationError(true, true, "https://example.com", "Error msg")).toBeNull();
+  });
+
+  it("returns error message when value is invalid", () => {
+    expect(getBaseUrlValidationError(true, true, "notaurl", "Invalid URL")).toBe("Invalid URL");
   });
 });

--- a/tests/unit/lib/validation/base-url.test.ts
+++ b/tests/unit/lib/validation/base-url.test.ts
@@ -95,6 +95,10 @@ describe("isValidBaseUrl", () => {
     it("rejects IPv6 unique-local fc00::", () => {
       expect(isValidBaseUrl("http://[fc00::1]")).toBe(false);
     });
+
+    it("rejects IPv6 unique-local fd00:: (upper half of fc00::/7)", () => {
+      expect(isValidBaseUrl("http://[fd00::1]")).toBe(false);
+    });
   });
 
   describe("SSRF mitigations — embedded credentials", () => {
@@ -117,8 +121,8 @@ describe("getBaseUrlValidationError", () => {
     expect(getBaseUrlValidationError(true, false, "bad", "Error msg")).toBeNull();
   });
 
-  it("returns null when value is empty", () => {
-    expect(getBaseUrlValidationError(true, true, "", "Error msg")).toBeNull();
+  it("returns error message when enabled, touched, and value is empty (required)", () => {
+    expect(getBaseUrlValidationError(true, true, "", "Error msg")).toBe("Error msg");
   });
 
   it("returns null when value is valid", () => {

--- a/tests/unit/services/issue-provider/factory.test.ts
+++ b/tests/unit/services/issue-provider/factory.test.ts
@@ -1,4 +1,7 @@
-/** @jest-environment node */
+/**
+ * Unit tests for the provider adapter factory — createAdapter, baseUrl normalization.
+ * @jest-environment node
+ */
 
 jest.mock("@/services/issue-provider/github/github", () => ({
   GitHubAdapter: jest.fn().mockImplementation(() => ({
@@ -55,6 +58,9 @@ jest.mock("@/services/issue-provider/registry", () => ({
 import { AsanaAdapter } from "@/services/issue-provider/asana/asana";
 import { BacklogAdapter } from "@/services/issue-provider/backlog/backlog";
 import { createAdapter } from "@/services/issue-provider/factory";
+import { GitHubAdapter } from "@/services/issue-provider/github/github";
+import { GitLabAdapter } from "@/services/issue-provider/gitlab/gitlab";
+import { JiraAdapter } from "@/services/issue-provider/jira/jira";
 import { TrelloAdapter } from "@/services/issue-provider/trello/trello";
 
 describe("createAdapter — post-enum removal (T010/T011)", () => {
@@ -86,5 +92,46 @@ describe("createAdapter — post-enum removal (T010/T011)", () => {
     const adapter = createAdapter("BACKLOG", { baseUrl: "https://myspace.backlog.com", apiKey: "backlog-key" });
     expect(adapter).toBeDefined();
     expect(BacklogAdapter).toHaveBeenCalledWith("https://myspace.backlog.com", "backlog-key");
+  });
+});
+
+describe("createAdapter — baseUrl normalization", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("passes trimmed baseUrl to GitHubAdapter", () => {
+    createAdapter("GITHUB", { token: "ghp_test" }, "https://github.example.com");
+    expect(GitHubAdapter).toHaveBeenCalledWith("ghp_test", "https://github.example.com");
+  });
+
+  it("passes undefined when baseUrl is undefined for GitHub", () => {
+    createAdapter("GITHUB", { token: "ghp_test" });
+    expect(GitHubAdapter).toHaveBeenCalledWith("ghp_test", undefined);
+  });
+
+  it("passes undefined when baseUrl is null for GitHub", () => {
+    createAdapter("GITHUB", { token: "ghp_test" }, null);
+    expect(GitHubAdapter).toHaveBeenCalledWith("ghp_test", undefined);
+  });
+
+  it("converts whitespace-only baseUrl to undefined for GitHub", () => {
+    createAdapter("GITHUB", { token: "ghp_test" }, "  ");
+    expect(GitHubAdapter).toHaveBeenCalledWith("ghp_test", undefined);
+  });
+
+  it("trims whitespace from baseUrl before passing to GitHubAdapter", () => {
+    createAdapter("GITHUB", { token: "ghp_test" }, "  https://github.example.com  ");
+    expect(GitHubAdapter).toHaveBeenCalledWith("ghp_test", "https://github.example.com");
+  });
+
+  it("passes trimmed baseUrl to GitLabAdapter", () => {
+    createAdapter("GITLAB", { token: "glpat_test" }, "https://gitlab.example.com");
+    expect(GitLabAdapter).toHaveBeenCalledWith("glpat_test", "https://gitlab.example.com");
+  });
+
+  it("ignores baseUrl for Jira (embedded in credentials)", () => {
+    createAdapter("JIRA", { baseUrl: "https://jira.example.com", email: "u@e.com", apiToken: "tok" }, "https://other.example.com");
+    expect(JiraAdapter).toHaveBeenCalledWith("https://jira.example.com", "u@e.com", "tok");
   });
 });

--- a/tests/unit/services/issue-provider/github.test.ts
+++ b/tests/unit/services/issue-provider/github.test.ts
@@ -1,4 +1,7 @@
-/** @jest-environment node */
+/**
+ * Unit tests for the GitHubAdapter — connection, CRUD, pagination, baseUrl, reviewer PR fetching.
+ * @jest-environment node
+ */
 
 jest.mock("axios", () => ({
   create: jest.fn().mockReturnValue({
@@ -98,6 +101,16 @@ describe("GitHubAdapter", () => {
       const adapter = new GitHubAdapter("ghp_test");
       const projects = await adapter.listProjects();
       expect(projects).toHaveLength(101);
+    });
+
+    it("throws when listProjects exceeds MAX_PAGES", async () => {
+      for (let i = 0; i < 20; i++) {
+        mockAxiosInstance.get.mockResolvedValueOnce({
+          data: Array(100).fill({ full_name: "owner/repo" }),
+        });
+      }
+      const adapter = new GitHubAdapter("ghp_test");
+      await expect(adapter.listProjects()).rejects.toThrow("MAX_PAGES");
     });
   });
 
@@ -235,6 +248,16 @@ describe("GitHubAdapter", () => {
       expect(issues[0].isUnassigned).toBe(true);
       expect(issues[0].externalId).toBe("5");
     });
+
+    it("throws when fetchUnassignedIssues exceeds MAX_PAGES", async () => {
+      for (let i = 0; i < 20; i++) {
+        mockAxiosInstance.get.mockResolvedValueOnce({
+          data: Array(100).fill(makeGitHubIssue({ assignee: null })),
+        });
+      }
+      const adapter = new GitHubAdapter("ghp_test");
+      await expect(adapter.fetchUnassignedIssues("owner/repo")).rejects.toThrow("MAX_PAGES");
+    });
   });
 
   describe("closeIssue", () => {
@@ -246,6 +269,12 @@ describe("GitHubAdapter", () => {
         "/repos/owner/repo/issues/42",
         { state: "closed" },
       );
+    });
+
+    it("throws when PATCH returns non-2xx status", async () => {
+      mockAxiosInstance.patch.mockResolvedValue({ status: 403, data: { message: "Forbidden" } });
+      const adapter = new GitHubAdapter("ghp_test");
+      await expect(adapter.closeIssue("owner/repo", "42")).rejects.toThrow("closeIssue failed");
     });
   });
 
@@ -259,10 +288,32 @@ describe("GitHubAdapter", () => {
         { body: "LGTM" },
       );
     });
+
+    it("throws when POST returns non-2xx status", async () => {
+      mockAxiosInstance.post.mockResolvedValue({ status: 403, data: { message: "Forbidden" } });
+      const adapter = new GitHubAdapter("ghp_test");
+      await expect(adapter.addComment("owner/repo", "42", "LGTM")).rejects.toThrow("addComment failed");
+    });
+  });
+
+  describe("getLogin — rejected promise recovery", () => {
+    it("clears cached rejected promise so a second call can succeed", async () => {
+      const error = new Error("Network error");
+      mockAxiosInstance.get
+        .mockRejectedValueOnce(error)
+        .mockResolvedValueOnce({ data: { login: "testuser" } });
+      const adapter = new GitHubAdapter("ghp_test");
+
+      await expect(adapter.testConnection()).rejects.toThrow("Network error");
+
+      mockAxiosInstance.get.mockClear();
+      mockAxiosInstance.get.mockResolvedValue({ data: { login: "testuser" } });
+      await expect(adapter.testConnection()).resolves.toBeUndefined();
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith("/user");
+    });
   });
 });
 
-// T007 — US1: GitHubAdapter baseUrl resolution
 describe("GitHubAdapter — baseUrl resolution", () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/tests/unit/services/issue-provider/github.test.ts
+++ b/tests/unit/services/issue-provider/github.test.ts
@@ -170,21 +170,6 @@ describe("GitHubAdapter", () => {
       expect(mockAxiosInstance.get).toHaveBeenCalledWith("/search/issues", expect.anything());
     });
 
-    it("fetches reviewer-requested PRs via Search API (FR-011)", async () => {
-      mockAxiosInstance.get
-        .mockResolvedValueOnce({ data: { login: "testuser" } })
-        .mockResolvedValueOnce({ data: [] })
-        .mockResolvedValueOnce({
-          data: {
-            items: [makeSearchItem({ number: 99, title: "Team review PR" })],
-          },
-        });
-      const adapter = new GitHubAdapter("ghp_test");
-      const issues = await adapter.fetchAssignedIssues("owner/repo");
-      expect(issues).toHaveLength(1);
-      expect(issues[0].externalId).toBe("99");
-    });
-
     it("propagates Search API 422/403 errors (C-1.9)", async () => {
       mockAxiosInstance.get
         .mockResolvedValueOnce({ data: { login: "testuser" } })
@@ -215,10 +200,36 @@ describe("GitHubAdapter", () => {
       await expect(adapter.fetchAssignedIssues("owner/")).rejects.toThrow("Invalid GitHub project ID");
     });
 
+    it("throws on invalid projectExternalId (empty owner segment) — T-4", async () => {
+      mockAxiosInstance.get.mockResolvedValueOnce({ data: { login: "testuser" } });
+      const adapter = new GitHubAdapter("ghp_test");
+      await expect(adapter.fetchAssignedIssues("/repo")).rejects.toThrow("Invalid GitHub project ID");
+    });
+
     it("throws on invalid projectExternalId (too many segments) — C-1", async () => {
       mockAxiosInstance.get.mockResolvedValueOnce({ data: { login: "testuser" } });
       const adapter = new GitHubAdapter("ghp_test");
       await expect(adapter.fetchAssignedIssues("owner/repo/extra")).rejects.toThrow("Invalid GitHub project ID");
+    });
+
+    it("maps milestone.due_on to dueDate — T-6", async () => {
+      mockAxiosInstance.get
+        .mockResolvedValueOnce({ data: { login: "testuser" } })
+        .mockResolvedValueOnce({ data: [makeGitHubIssue({ number: 1, milestone: { due_on: "2026-12-31T00:00:00Z" } })] })
+        .mockResolvedValueOnce({ data: { items: [] } });
+      const adapter = new GitHubAdapter("ghp_test");
+      const issues = await adapter.fetchAssignedIssues("owner/repo");
+      expect(issues[0].dueDate).toEqual(new Date("2026-12-31T00:00:00Z"));
+    });
+
+    it("sets dueDate to null when milestone is absent — T-6", async () => {
+      mockAxiosInstance.get
+        .mockResolvedValueOnce({ data: { login: "testuser" } })
+        .mockResolvedValueOnce({ data: [makeGitHubIssue({ number: 1, milestone: null })] })
+        .mockResolvedValueOnce({ data: { items: [] } });
+      const adapter = new GitHubAdapter("ghp_test");
+      const issues = await adapter.fetchAssignedIssues("owner/repo");
+      expect(issues[0].dueDate).toBeNull();
     });
 
     it("throws when fetchReviewerPrs exceeds MAX_PAGES (I-11)", async () => {
@@ -296,8 +307,8 @@ describe("GitHubAdapter", () => {
     });
   });
 
-  describe("getLogin — rejected promise recovery", () => {
-    it("clears cached rejected promise so a second call can succeed", async () => {
+  describe("getLogin — caching behaviour", () => {
+    it("clears cached rejected promise so a second call can succeed — T-5 error path", async () => {
       const error = new Error("Network error");
       mockAxiosInstance.get
         .mockRejectedValueOnce(error)
@@ -310,6 +321,21 @@ describe("GitHubAdapter", () => {
       mockAxiosInstance.get.mockResolvedValue({ data: { login: "testuser" } });
       await expect(adapter.testConnection()).resolves.toBeUndefined();
       expect(mockAxiosInstance.get).toHaveBeenCalledWith("/user");
+    });
+
+    it("caches resolved login so a second fetchAssignedIssues call does not re-request /user — T-5", async () => {
+      mockAxiosInstance.get
+        .mockResolvedValueOnce({ data: { login: "testuser" } }) // getLogin (1st call)
+        .mockResolvedValueOnce({ data: [] })                    // assigned issues (1st)
+        .mockResolvedValueOnce({ data: { items: [] } })         // reviewer prs (1st)
+        .mockResolvedValueOnce({ data: [] })                    // assigned issues (2nd)
+        .mockResolvedValueOnce({ data: { items: [] } });        // reviewer prs (2nd)
+      const adapter = new GitHubAdapter("ghp_test");
+      await adapter.fetchAssignedIssues("owner/repo");
+      await adapter.fetchAssignedIssues("owner/repo");
+      // /user is called only once; subsequent calls use the cached promise
+      expect(mockAxiosInstance.get).toHaveBeenCalledTimes(5);
+      expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(1, "/user");
     });
   });
 });
@@ -345,6 +371,18 @@ describe("GitHubAdapter — baseUrl resolution", () => {
     new GitHubAdapter("ghp_test", null);
     expect(axios.create).toHaveBeenCalledWith(
       expect.objectContaining({ baseURL: "https://api.github.com" }),
+    );
+  });
+
+  it("calls GET /user/repos using correct path when constructed with GHE baseUrl — T-7", async () => {
+    (axios.create as jest.Mock).mockReturnValue(mockAxiosInstance);
+    const adapter = new GitHubAdapter("ghp_test", "https://github.example.com");
+    mockAxiosInstance.get.mockResolvedValue({ data: [{ full_name: "org/repo" }] });
+    const projects = await adapter.listProjects();
+    expect(projects).toEqual([{ externalId: "org/repo", displayName: "org/repo" }]);
+    expect(mockAxiosInstance.get).toHaveBeenCalledWith(
+      "/user/repos",
+      expect.objectContaining({ params: expect.objectContaining({ per_page: 100, page: 1 }) }),
     );
   });
 });

--- a/tests/unit/services/issue-provider/github.test.ts
+++ b/tests/unit/services/issue-provider/github.test.ts
@@ -261,3 +261,39 @@ describe("GitHubAdapter", () => {
     });
   });
 });
+
+// T007 — US1: GitHubAdapter baseUrl resolution
+describe("GitHubAdapter — baseUrl resolution", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (axios.create as jest.Mock).mockReturnValue(mockAxiosInstance);
+  });
+
+  it("uses https://api.github.com when no baseUrl is provided", () => {
+    new GitHubAdapter("ghp_test");
+    expect(axios.create).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: "https://api.github.com" }),
+    );
+  });
+
+  it("uses ${baseUrl}/api/v3 when baseUrl is provided", () => {
+    new GitHubAdapter("ghp_test", "https://github.example.com");
+    expect(axios.create).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: "https://github.example.com/api/v3" }),
+    );
+  });
+
+  it("strips trailing slash from baseUrl before appending /api/v3", () => {
+    new GitHubAdapter("ghp_test", "https://github.example.com/");
+    expect(axios.create).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: "https://github.example.com/api/v3" }),
+    );
+  });
+
+  it("uses https://api.github.com when baseUrl is null", () => {
+    new GitHubAdapter("ghp_test", null);
+    expect(axios.create).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: "https://api.github.com" }),
+    );
+  });
+});

--- a/tests/unit/services/issue-provider/registry.test.ts
+++ b/tests/unit/services/issue-provider/registry.test.ts
@@ -25,7 +25,7 @@ describe("getAllProviders()", () => {
 
   it("returns providers with correct baseUrlMode", () => {
     const byType = Object.fromEntries(getAllProviders().map((p) => [p.type, p]));
-    expect(byType["GITHUB"].baseUrlMode).toBe("none");
+    expect(byType["GITHUB"].baseUrlMode).toBe("optional");
     expect(byType["JIRA"].baseUrlMode).toBe("required");
     expect(byType["REDMINE"].baseUrlMode).toBe("required");
     expect(byType["GITLAB"].baseUrlMode).toBe("optional");


### PR DESCRIPTION
## Summary
- Add `baseUrl` field to GitHub provider configuration to support GitHub Enterprise Server instances.
- Validate the base URL format on save; show an inline error for invalid values.
- Disable the base URL input unless the GitHub Enterprise checkbox is checked.
- Extend the GitHub API client to prefix all requests with the configured base URL when set.
- Add pagination support for GitHub API calls to handle repositories with large issue counts.
- Enhance provider API routes with improved error handling and input validation.
- Add E2E tests covering the full GitHub Enterprise provider configuration flow.
- Add unit tests for URL validation, API client URL construction, and provider factory logic.