### PR TITLE
Auto-build container image on release tag creation

### DIFF
--- a/.github/workflows/release-tag-backmerge.yml
+++ b/.github/workflows/release-tag-backmerge.yml
@@ -15,6 +15,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      actions: write
 
     steps:
       - name: Checkout
@@ -45,6 +46,16 @@ jobs:
               git ls-remote --tags origin "refs/tags/v${{ env.VERSION }}" | grep -q . || exit 1
             }
           fi
+
+      - name: Trigger container build for the new tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ env.VERSION }}
+        run: |
+          # workflow_dispatch is exempt from the GITHUB_TOKEN "no chained workflows"
+          # restriction, so this reliably starts container.yml against the new tag.
+          # Requires the "actions: write" permission declared above.
+          gh workflow run container.yml --ref "v${VERSION}"
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
## Summary
- Trigger `container.yml` automatically after `release-tag-backmerge.yml` creates a new `v<version>` release tag, so release images are built and pushed without manual intervention.
- Dispatch the build via `gh workflow run container.yml --ref "v<version>"`, which relies on `workflow_dispatch` being exempt from the `GITHUB_TOKEN` "no chained workflows" restriction (a plain tag push by `GITHUB_TOKEN` would not start `container.yml`).
- Add the `actions: write` permission required for `gh workflow run` to dispatch the workflow.
- Pass the version through an `env:` variable as a defensive practice, even though it originates from the trusted `package.json`.

## Test plan
- [ ] Merge a `release/*` PR into `main` and confirm `release-tag-backmerge.yml` creates the tag and dispatches `container.yml`.
- [ ] Confirm `container.yml` runs against the new tag and pushes the `amd64`/`arm64` images and multi-arch manifest to DockerHub.